### PR TITLE
chore: fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ For a great intro and overview, watch the first 10 minutes of this video by Mart
 
 [![Intro to the Modern State of Synchronization](https://f.system3.md/cdn-cgi/image/format=auto,width=600/crdt-explainer-thumnail.png)](https://youtube.com/watch?v=x7drE24geUw)
 
-For more, check out this video: [Intro to the Modern State of Synchronization](https://youtu.be/tSvlvMTHhWY?si=Rp6FepkeS7N6y3zO) by [Kevin Jahns](https://github.com/dmonad). Jahns is the maintainer of [Yjs](https://docs.yjs.dev/), which is the the open source CRDT that we use in Relay.
+For more, check out this video: [Intro to the Modern State of Synchronization](https://youtu.be/tSvlvMTHhWY?si=Rp6FepkeS7N6y3zO) by [Kevin Jahns](https://github.com/dmonad). Jahns is the maintainer of [Yjs](https://docs.yjs.dev/), which is the open source CRDT that we use in Relay.
 
 ## What can I do with Relay?
 


### PR DESCRIPTION
## Summary
- fix duplicate word typo in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687970b05ce48321b704c84320114420