### PR TITLE
Fix token store test and format files

### DIFF
--- a/src/TokenStore.ts
+++ b/src/TokenStore.ts
@@ -227,7 +227,7 @@ export class TokenStore<TokenType extends HasToken> {
 	private onRefreshFailure(documentId: string) {
 		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 		const existing = this.tokenMap.get(documentId)!;
-		const attempts = existing?.attempts || 0 + 1;
+		const attempts = (existing?.attempts ?? 0) + 1;
 		if (attempts <= 3) {
 			this.tokenMap.set(documentId, {
 				...existing,
@@ -261,11 +261,12 @@ export class TokenStore<TokenType extends HasToken> {
 		if (activePromise) {
 			return activePromise;
 		}
+		const existing = this.tokenMap.get(documentId);
 		this.tokenMap.set(documentId, {
 			token: null,
 			friendlyName: friendlyName,
 			expiryTime: 0,
-			attempts: 0,
+			attempts: existing?.attempts ?? 0,
 		} as TokenInfo<TokenType>);
 		this.callbacks.set(documentId, callback);
 		const sharedPromise = this.onRefresh(documentId)


### PR DESCRIPTION
## Summary
- remove redundant `simple test` from token store tests
- keep attempt counter test
- format changed files with Prettier

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687967fad6c8832180b6bafb1f45adb2