### PR TITLE
Fix: unwanted note reconnect on navigation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # vscode
-.vscode 
+.vscode
 
 # Intellij
 *.iml
@@ -19,3 +19,9 @@ data.json
 # Exclude macOS Finder (System Explorer) View States
 .DS_Store
 vaults/
+
+# Development
+dev.sh
+
+# Claude Code
+.claude/

--- a/__tests__/UserDisconnectedIntent.test.ts
+++ b/__tests__/UserDisconnectedIntent.test.ts
@@ -1,0 +1,257 @@
+"use strict";
+
+/**
+ * Tests for the userDisconnectedIntent flag pattern.
+ *
+ * This flag tracks whether a user has EXPLICITLY disconnected a document
+ * via the UI toggle, as opposed to the document being disconnected due to:
+ * - View lifecycle (release() when navigating away)
+ * - Network issues
+ * - Other system-initiated disconnections
+ *
+ * The flag should:
+ * - Default to false (documents should connect by default)
+ * - Only be set to true via explicit user action (toggleConnection)
+ * - NOT be affected by disconnect() calls
+ * - Be used by LiveViews.getViews() to determine shouldConnect for new LiveView instances
+ *
+ * Bug context: When a user disconnects a note and navigates away/back,
+ * the note was auto-reconnecting because getViews() created new LiveView
+ * instances with shouldConnect=true by default, ignoring user intent.
+ *
+ * This test file tests the FLAG BEHAVIOR PATTERN in isolation, without
+ * requiring full Obsidian dependencies. The actual Document/Canvas classes
+ * follow this same pattern.
+ *
+ * For E2E verification, use the live-debug skill:
+ *   python .claude/scripts/obsidian_debug.py --vault <name> relay file-status "test.md"
+ */
+
+/**
+ * Minimal class that mimics the userDisconnectedIntent pattern
+ * implemented in Document and Canvas.
+ */
+class MockDocumentWithUserIntent {
+	/**
+	 * Tracks whether the user has explicitly disconnected this document.
+	 * - Default: false (connect by default)
+	 * - Set to true: only via explicit user action (toggleConnection)
+	 * - NOT modified by: disconnect(), release(), network issues
+	 */
+	userDisconnectedIntent: boolean = false;
+
+	// Simulates provider's shouldConnect (affected by disconnect())
+	private _providerShouldConnect: boolean = true;
+
+	/**
+	 * Simulates the disconnect() method from HasProvider.
+	 * This sets provider.shouldConnect = false but should NOT
+	 * affect userDisconnectedIntent.
+	 */
+	disconnect(): void {
+		this._providerShouldConnect = false;
+		// NOTE: userDisconnectedIntent is NOT modified here
+	}
+
+	/**
+	 * Simulates the connect() method from HasProvider.
+	 */
+	connect(): void {
+		this._providerShouldConnect = true;
+	}
+
+	/**
+	 * Simulates intent getter (derived from provider.shouldConnect).
+	 */
+	get intent(): "connected" | "disconnected" {
+		return this._providerShouldConnect ? "connected" : "disconnected";
+	}
+}
+
+/**
+ * Simulates LiveView behavior with the userDisconnectedIntent fix.
+ */
+class MockLiveView {
+	shouldConnect: boolean;
+	document: MockDocumentWithUserIntent;
+
+	constructor(document: MockDocumentWithUserIntent, shouldConnect = true) {
+		this.document = document;
+		this.shouldConnect = shouldConnect;
+	}
+
+	/**
+	 * Simulates the toggleConnection() method with the fix applied.
+	 */
+	toggleConnection(): void {
+		this.shouldConnect = !this.shouldConnect;
+		// THE FIX: Track explicit user disconnect intent
+		this.document.userDisconnectedIntent = !this.shouldConnect;
+		if (this.shouldConnect) {
+			this.document.connect();
+		} else {
+			this.document.disconnect();
+		}
+	}
+
+	/**
+	 * Simulates release() when navigating away.
+	 */
+	release(): void {
+		this.document.disconnect();
+		// NOTE: userDisconnectedIntent is NOT modified here
+	}
+}
+
+/**
+ * Simulates getViews() creating a new LiveView with the fix applied.
+ */
+function createLiveViewFromDocument(
+	doc: MockDocumentWithUserIntent,
+): MockLiveView {
+	// THE FIX: Use userDisconnectedIntent to determine shouldConnect
+	const shouldConnect = !doc.userDisconnectedIntent;
+	return new MockLiveView(doc, shouldConnect);
+}
+
+describe("userDisconnectedIntent flag pattern", () => {
+	describe("Document flag behavior", () => {
+		let doc: MockDocumentWithUserIntent;
+
+		beforeEach(() => {
+			doc = new MockDocumentWithUserIntent();
+		});
+
+		it("should default userDisconnectedIntent to false", () => {
+			expect(doc.userDisconnectedIntent).toBe(false);
+		});
+
+		it("should preserve userDisconnectedIntent=true after disconnect()", () => {
+			doc.userDisconnectedIntent = true;
+			doc.disconnect();
+			expect(doc.userDisconnectedIntent).toBe(true);
+		});
+
+		it("should preserve userDisconnectedIntent=false after disconnect()", () => {
+			expect(doc.userDisconnectedIntent).toBe(false);
+			doc.disconnect();
+			expect(doc.userDisconnectedIntent).toBe(false);
+		});
+	});
+
+	describe("LiveView toggleConnection behavior", () => {
+		let doc: MockDocumentWithUserIntent;
+		let view: MockLiveView;
+
+		beforeEach(() => {
+			doc = new MockDocumentWithUserIntent();
+			view = new MockLiveView(doc);
+		});
+
+		it("should set userDisconnectedIntent=true when user disconnects", () => {
+			expect(doc.userDisconnectedIntent).toBe(false);
+			view.toggleConnection(); // User clicks to disconnect
+			expect(doc.userDisconnectedIntent).toBe(true);
+			expect(view.shouldConnect).toBe(false);
+		});
+
+		it("should set userDisconnectedIntent=false when user reconnects", () => {
+			view.toggleConnection(); // Disconnect
+			expect(doc.userDisconnectedIntent).toBe(true);
+
+			view.toggleConnection(); // Reconnect
+			expect(doc.userDisconnectedIntent).toBe(false);
+			expect(view.shouldConnect).toBe(true);
+		});
+	});
+
+	describe("Navigation scenario (the bug fix)", () => {
+		it("should preserve disconnect intent across navigation", () => {
+			// Setup: Document exists, user opens it
+			const doc = new MockDocumentWithUserIntent();
+			let view = new MockLiveView(doc);
+
+			// User explicitly disconnects
+			view.toggleConnection();
+			expect(doc.userDisconnectedIntent).toBe(true);
+			expect(view.shouldConnect).toBe(false);
+
+			// User navigates away (release is called)
+			view.release();
+
+			// User navigates back (new LiveView is created)
+			// THIS IS THE BUG FIX: getViews() now uses userDisconnectedIntent
+			view = createLiveViewFromDocument(doc);
+
+			// New view should respect user's disconnect intent
+			expect(view.shouldConnect).toBe(false);
+			expect(doc.userDisconnectedIntent).toBe(true);
+		});
+
+		it("should auto-connect when user never explicitly disconnected", () => {
+			// Setup: Document exists, user opens it
+			const doc = new MockDocumentWithUserIntent();
+			let view = new MockLiveView(doc);
+			expect(view.shouldConnect).toBe(true);
+
+			// User navigates away without disconnecting
+			view.release();
+
+			// User navigates back
+			view = createLiveViewFromDocument(doc);
+
+			// New view should auto-connect (default behavior)
+			expect(view.shouldConnect).toBe(true);
+			expect(doc.userDisconnectedIntent).toBe(false);
+		});
+
+		it("should auto-connect after user explicitly reconnects", () => {
+			const doc = new MockDocumentWithUserIntent();
+			let view = new MockLiveView(doc);
+
+			// User disconnects then reconnects
+			view.toggleConnection(); // Disconnect
+			view.toggleConnection(); // Reconnect
+			expect(doc.userDisconnectedIntent).toBe(false);
+
+			// User navigates away
+			view.release();
+
+			// User navigates back
+			view = createLiveViewFromDocument(doc);
+
+			// New view should auto-connect
+			expect(view.shouldConnect).toBe(true);
+		});
+	});
+});
+
+/**
+ * Integration behavior documentation (verified manually via E2E):
+ *
+ * When user clicks disconnect toggle in LiveView:
+ * 1. LiveView.toggleConnection() is called
+ * 2. Sets this.shouldConnect = false
+ * 3. Sets this.document.userDisconnectedIntent = true
+ * 4. Calls this.document.disconnect()
+ *
+ * When user navigates away:
+ * 1. LiveView.release() is called
+ * 2. Calls this.document.disconnect()
+ * 3. userDisconnectedIntent is NOT changed (stays true if user disconnected)
+ *
+ * When user navigates back:
+ * 1. LiveViewManager.getViews() is called
+ * 2. Creates new LiveView with shouldConnect = !doc.userDisconnectedIntent
+ * 3. If user had disconnected, new LiveView has shouldConnect = false
+ * 4. Document stays disconnected as user intended
+ *
+ * When user clicks connect toggle:
+ * 1. LiveView.toggleConnection() is called
+ * 2. Sets this.shouldConnect = true
+ * 3. Sets this.document.userDisconnectedIntent = false
+ * 4. Calls this.document.connect()
+ *
+ * E2E verification command:
+ *   python .claude/scripts/obsidian_debug.py --vault <name> relay file-status "test.md"
+ */

--- a/src/HasProvider.ts
+++ b/src/HasProvider.ts
@@ -58,6 +58,9 @@ export class HasProvider extends HasLogging {
 	path?: string;
 	ydoc: Y.Doc;
 	clientToken: ClientToken;
+	// Track if provider has ever synced. We use our own flag because
+	// _provider.synced can be reset to false on reconnection.
+	_providerSynced: boolean = false;
 	private _offConnectionError: () => void;
 	private _offState: () => void;
 	listeners: Map<unknown, Listener>;
@@ -216,7 +219,7 @@ export class HasProvider extends HasLogging {
 	}
 
 	public get synced(): boolean {
-		return this._provider.synced;
+		return this._providerSynced;
 	}
 
 	disconnect() {
@@ -249,11 +252,12 @@ export class HasProvider extends HasLogging {
 	}
 
 	onceProviderSynced(): Promise<void> {
-		if (this._provider.synced) {
+		if (this._providerSynced) {
 			return Promise.resolve();
 		}
 		return new Promise((resolve) => {
 			this._provider.once("synced", () => {
+				this._providerSynced = true;
 				resolve();
 			});
 		});

--- a/src/LiveViews.ts
+++ b/src/LiveViews.ts
@@ -203,6 +203,8 @@ export class RelayCanvasView implements S3View {
 
 	toggleConnection() {
 		this.shouldConnect = !this.shouldConnect;
+		// Track explicit user disconnect intent (persists across navigation)
+		this.canvas.userDisconnectedIntent = !this.shouldConnect;
 		if (this.shouldConnect) {
 			this.canvas.connect().then((connected) => {
 				if (!connected) {
@@ -396,6 +398,8 @@ export class LiveView<ViewType extends TextFileView>
 
 	toggleConnection() {
 		this.shouldConnect = !this.shouldConnect;
+		// Track explicit user disconnect intent (persists across navigation)
+		this.document.userDisconnectedIntent = !this.shouldConnect;
 		if (this.shouldConnect) {
 			this.document.connect().then((connected) => {
 				if (!connected) {
@@ -871,10 +875,13 @@ export class LiveViewManager {
 					views.push(view);
 				} else if (folder.ready) {
 					const doc = folder.proxy.getDoc(viewFilePath);
+					// Preserve user's explicit disconnect intent across navigation
+					const shouldConnect = !doc.userDisconnectedIntent;
 					const view = new LiveView<typeof textFileView>(
 						this,
 						textFileView,
 						doc,
+						shouldConnect,
 					);
 					views.push(view);
 				} else {
@@ -898,7 +905,14 @@ export class LiveViewManager {
 				} else if (folder.ready) {
 					const canvas = folder.getFile(canvasView.file);
 					if (isCanvas(canvas)) {
-						const view = new RelayCanvasView(this, canvasView, canvas);
+						// Preserve user's explicit disconnect intent across navigation
+						const shouldConnect = !canvas.userDisconnectedIntent;
+						const view = new RelayCanvasView(
+							this,
+							canvasView,
+							canvas,
+							shouldConnect,
+						);
 						views.push(view);
 					} else {
 						this.log(`Skipping canvas view connection for ${viewFilePath}`);

--- a/src/LiveViews.ts
+++ b/src/LiveViews.ts
@@ -991,21 +991,21 @@ export class LiveViewManager {
 			}
 			const folder = this.sharedFolders.lookup(viewFilePath);
 			if (folder && canvasView.file) {
-				const canvas = folder.getFile(canvasView.file);
-				if (isCanvas(canvas)) {
-					if (!this.loginManager.loggedIn) {
-						const view = new LoggedOutView(this, canvasView, () => {
-							return this.loginManager.openLoginPage();
-						});
-						views.push(view);
-					} else if (folder.ready) {
+				if (!this.loginManager.loggedIn) {
+					const view = new LoggedOutView(this, canvasView, () => {
+						return this.loginManager.openLoginPage();
+					});
+					views.push(view);
+				} else if (folder.ready) {
+					const canvas = folder.getFile(canvasView.file);
+					if (isCanvas(canvas)) {
 						const view = new RelayCanvasView(this, canvasView, canvas);
 						views.push(view);
 					} else {
-						this.log(`Folder not ready, skipping views. folder=${folder.path}`);
+						this.log(`Skipping canvas view connection for ${viewFilePath}`);
 					}
 				} else {
-					this.log(`Skipping canvas view connection for ${viewFilePath}`);
+					this.log(`Folder not ready, skipping views. folder=${folder.path}`);
 				}
 			}
 		});

--- a/src/LiveViews.ts
+++ b/src/LiveViews.ts
@@ -124,65 +124,24 @@ export class LoggedOutView implements S3View {
 		this.login = login;
 	}
 
-	setLoginIcon(): void {
-		const viewHeaderElement =
-			this.view.containerEl.querySelector(".view-header");
-		const viewHeaderLeftElement = 
-			this.view.containerEl.querySelector(".view-header-left");
-		
-		if (viewHeaderElement && viewHeaderLeftElement) {
-			this.clearLoginButton();
-			
-			// Create login button element
-			const loginButton = document.createElement("button");
-			loginButton.className = "view-header-left system3-login-button";
-			loginButton.textContent = "Login to enable Live edits";
-			loginButton.setAttribute("aria-label", "Login to enable Live edits");
-			loginButton.setAttribute("tabindex", "0");
-			
-			// Add click handler
-			loginButton.addEventListener("click", async () => {
-				await this.login();
-			});
-			
-			// Insert after view-header-left
-			viewHeaderLeftElement.insertAdjacentElement("afterend", loginButton);
-		}
-	}
-
-	clearLoginButton() {
-		const existingButton = this.view.containerEl.querySelector(".system3-login-button");
-		if (existingButton) {
-			existingButton.remove();
-		}
-	}
-
 	attach(): Promise<S3View> {
-		// Use header button approach on mobile for Obsidian >=1.11.0 to avoid banner positioning issues
-		if (Platform.isMobile && requireApiVersion("1.11.0")) {
-			this.setLoginIcon();
-		} else {
-			this.banner = new Banner(
-				this.view,
-				"Login to enable Live edits",
-				async () => {
-					return await this.login();
-				},
-			);
-		}
+		this.banner = new Banner(
+			this.view,
+			{ short: "Login to Relay", long: "Login to enable Live edits" },
+			async () => {
+				return await this.login();
+			},
+		);
 		return Promise.resolve(this);
 	}
 
 	release() {
 		this.banner?.destroy();
-		this.clearLoginButton();
 	}
 
 	destroy() {
-		this.release();
 		this.banner?.destroy();
 		this.banner = undefined;
-		this.clearLoginButton();
 		this.view = null as any;
 	}
 }
@@ -260,7 +219,7 @@ export class RelayCanvasView implements S3View {
 		if (this.shouldConnect) {
 			const banner = new Banner(
 				this.view,
-				"You're offline -- click to reconnect",
+				{ short: "Offline", long: "You're offline -- click to reconnect" },
 				async () => {
 					this._parent.networkStatus.checkStatus();
 					this.connect();
@@ -475,29 +434,15 @@ export class LiveView<ViewType extends TextFileView>
 		}
 	}
 
-	setMergeButton(): void {
-		const viewHeaderElement =
-			this.view.containerEl.querySelector(".view-header");
-		const viewHeaderLeftElement = 
-			this.view.containerEl.querySelector(".view-header-left");
-		
-		if (viewHeaderElement && viewHeaderLeftElement) {
-			this.clearMergeButton();
-			
-			// Create merge button element
-			const mergeButton = document.createElement("button");
-			mergeButton.className = "view-header-left system3-merge-button";
-			mergeButton.textContent = "Merge conflict";
-			mergeButton.setAttribute("aria-label", "Merge conflict -- click to resolve");
-			mergeButton.setAttribute("tabindex", "0");
-			
-			// Add click handler
-			mergeButton.addEventListener("click", async () => {
+	mergeBanner(): () => void {
+		this._banner = new Banner(
+			this.view,
+			{ short: "Merge conflict", long: "Merge conflict -- click to resolve" },
+			async () => {
 				const diskBuffer = await this.document.diskBuffer();
 				const stale = await this.document.checkStale();
 				if (!stale) {
-					this.clearMergeButton();
-					return;
+					return true;
 				}
 				this._parent.openDiffView({
 					file1: this.document,
@@ -505,7 +450,7 @@ export class LiveView<ViewType extends TextFileView>
 					showMergeOption: true,
 					onResolve: async () => {
 						this.document.clearDiskBuffer();
-						this.clearMergeButton();
+						this._banner?.destroy();
 						// Force view to sync to CRDT state after differ resolution
 						if (
 							this._plugin &&
@@ -515,53 +460,9 @@ export class LiveView<ViewType extends TextFileView>
 						}
 					},
 				});
-			});
-			
-			// Insert after view-header-left
-			viewHeaderLeftElement.insertAdjacentElement("afterend", mergeButton);
-		}
-	}
-
-	clearMergeButton() {
-		const existingButton = this.view.containerEl.querySelector(".system3-merge-button");
-		if (existingButton) {
-			existingButton.remove();
-		}
-	}
-
-	mergeBanner(): () => void {
-		// Use header button approach on mobile for Obsidian >=1.11.0 to avoid banner positioning issues
-		if (Platform.isMobile && requireApiVersion("1.11.0")) {
-			this.setMergeButton();
-		} else {
-			this._banner = new Banner(
-				this.view,
-				"Merge conflict -- click to resolve",
-				async () => {
-					const diskBuffer = await this.document.diskBuffer();
-					const stale = await this.document.checkStale();
-					if (!stale) {
-						return true;
-					}
-					this._parent.openDiffView({
-						file1: this.document,
-						file2: diskBuffer,
-						showMergeOption: true,
-						onResolve: async () => {
-							this.document.clearDiskBuffer();
-							// Force view to sync to CRDT state after differ resolution
-							if (
-								this._plugin &&
-								typeof this._plugin.syncViewToCRDT === "function"
-							) {
-								await this._plugin.syncViewToCRDT();
-							}
-						},
-					});
-					return true;
-				},
-			);
-		}
+				return true;
+			},
+		);
 		return () => {};
 	}
 
@@ -569,7 +470,7 @@ export class LiveView<ViewType extends TextFileView>
 		if (this.shouldConnect) {
 			const banner = new Banner(
 				this.view,
-				"You're offline -- click to reconnect",
+				{ short: "Offline", long: "You're offline -- click to reconnect" },
 				async () => {
 					this._parent.networkStatus.checkStatus();
 					this.connect();
@@ -725,7 +626,6 @@ export class LiveView<ViewType extends TextFileView>
 		this._viewActions = undefined;
 		this._banner?.destroy();
 		this._banner = undefined;
-		this.clearMergeButton();
 		if (this.offConnectionStatusSubscription) {
 			this.offConnectionStatusSubscription();
 			this.offConnectionStatusSubscription = undefined;
@@ -741,7 +641,6 @@ export class LiveView<ViewType extends TextFileView>
 	destroy() {
 		this.release();
 		this.clearViewActions();
-		this.clearMergeButton();
 		(this.view.leaf as any).rebuildView?.();
 		this._parent = null as any;
 		this.view = null as any;

--- a/src/main.ts
+++ b/src/main.ts
@@ -30,6 +30,7 @@ import {
 	RelayInstances,
 	initializeLogger,
 	flushLogs,
+	initializeMetrics,
 } from "./debug";
 import { getPatcher, Patcher } from "./Patcher";
 import { LiveTokenStore } from "./LiveTokenStore";
@@ -329,6 +330,7 @@ export default class Live extends Plugin {
 				disableConsole: false, // Disable console logging
 			},
 		);
+		initializeMetrics(this.app, (ref) => this.registerEvent(ref));
 		this.notifier = new ObsidianNotifier();
 
 		this.debug = curryLog("[System 3][Relay]", "debug");

--- a/src/plugins/ViewHookPlugin.ts
+++ b/src/plugins/ViewHookPlugin.ts
@@ -225,7 +225,10 @@ export class ViewHookPlugin extends HasLogging {
 		this.view.previewMode.renderer.set(this.document.text);
 		this.renderAll();
 
-		this.document.connect();
+		// Respect user's explicit disconnect intent
+		if (!this.document.userDisconnectedIntent) {
+			this.document.connect();
+		}
 		this.debug("ViewHookPlugin initialized");
 	}
 

--- a/src/types/obsidian-metrics.d.ts
+++ b/src/types/obsidian-metrics.d.ts
@@ -1,0 +1,149 @@
+/**
+ * Type declarations for the Obsidian Metrics API
+ *
+ * Copy this file into your plugin to get type-safe access to the metrics API.
+ *
+ * ## Accessing the API
+ *
+ * Access via the plugin instance:
+ * ```typescript
+ * const metricsPlugin = this.app.plugins.plugins['obsidian-metrics'] as ObsidianMetricsPlugin | undefined;
+ * const api = metricsPlugin?.api;
+ * ```
+ *
+ * ## Handling Plugin Load Order
+ *
+ * The metrics plugin emits 'obsidian-metrics:ready' when loaded. Listen for this
+ * event to handle cases where your plugin loads before obsidian-metrics:
+ *
+ * ```typescript
+ * class MyPlugin extends Plugin {
+ *   private metricsApi: IObsidianMetricsAPI | undefined;
+ *   private documentGauge: MetricInstance | undefined;
+ *
+ *   async onload() {
+ *     // Listen for metrics API becoming available (or re-initializing after reload)
+ *     this.registerEvent(
+ *       this.app.workspace.on('obsidian-metrics:ready', (api: IObsidianMetricsAPI) => {
+ *         this.initializeMetrics(api);
+ *       })
+ *     );
+ *
+ *     // Also try to get it immediately in case metrics plugin loaded first
+ *     const metricsPlugin = this.app.plugins.plugins['obsidian-metrics'] as ObsidianMetricsPlugin | undefined;
+ *     if (metricsPlugin?.api) {
+ *       this.initializeMetrics(metricsPlugin.api);
+ *     }
+ *   }
+ *
+ *   private initializeMetrics(api: IObsidianMetricsAPI) {
+ *     this.metricsApi = api;
+ *     // Metric creation is idempotent - safe to call multiple times
+ *     this.documentGauge = api.createGauge({
+ *       name: 'my_document_size_bytes',
+ *       help: 'Size of documents in bytes',
+ *       labelNames: ['document']
+ *     });
+ *   }
+ *
+ *   updateDocumentSize(doc: string, bytes: number) {
+ *     this.documentGauge?.labels({ document: doc }).set(bytes);
+ *   }
+ * }
+ * ```
+ *
+ * ## Key Points
+ *
+ * - **Do NOT cache the API or metrics long-term** - they become stale if obsidian-metrics reloads
+ * - Listen for 'obsidian-metrics:ready' and re-initialize your metrics each time it fires
+ * - Metric creation is idempotent: calling createGauge() with the same name returns the existing metric
+ * - It's safe to store metric references within an initialization cycle, but always re-create them
+ *   when 'obsidian-metrics:ready' fires
+ */
+
+export interface MetricLabels {
+	[key: string]: string;
+}
+
+export interface CounterOptions {
+	name: string;
+	help: string;
+	labelNames?: string[];
+}
+
+export interface GaugeOptions {
+	name: string;
+	help: string;
+	labelNames?: string[];
+}
+
+export interface HistogramOptions {
+	name: string;
+	help: string;
+	labelNames?: string[];
+	buckets?: number[];
+}
+
+export interface SummaryOptions {
+	name: string;
+	help: string;
+	labelNames?: string[];
+	percentiles?: number[];
+	maxAgeSeconds?: number;
+	ageBuckets?: number;
+}
+
+export interface LabeledMetricInstance {
+	inc(value?: number): void;
+	dec(value?: number): void;
+	set(value: number): void;
+	observe(value: number): void;
+	startTimer(): () => void;
+}
+
+export interface MetricInstance {
+	inc(value?: number, labels?: MetricLabels): void;
+	dec(value?: number, labels?: MetricLabels): void;
+	set(value: number, labels?: MetricLabels): void;
+	observe(value: number, labels?: MetricLabels): void;
+	startTimer(labels?: MetricLabels): () => void;
+	labels(labels: MetricLabels): LabeledMetricInstance;
+}
+
+export interface IObsidianMetricsAPI {
+	// Metric retrieval
+	getMetric(name: string): MetricInstance | undefined;
+	getAllMetrics(): Promise<string>;
+	clearMetric(name: string): boolean;
+	clearAllMetrics(): void;
+
+	// Metric creation (idempotent - returns existing metric if name matches)
+	createCounter(options: CounterOptions): MetricInstance;
+	createGauge(options: GaugeOptions): MetricInstance;
+	createHistogram(options: HistogramOptions): MetricInstance;
+	createSummary(options: SummaryOptions): MetricInstance;
+
+	// Convenience methods (create + optional initial value)
+	counter(name: string, help: string, value?: number): MetricInstance;
+	gauge(name: string, help: string, value?: number): MetricInstance;
+	histogram(name: string, help: string, buckets?: number[]): MetricInstance;
+	summary(name: string, help: string, percentiles?: number[]): MetricInstance;
+
+	// Timing utilities
+	createTimer(metricName: string): () => number;
+	measureAsync<T>(metricName: string, fn: () => Promise<T>): Promise<T>;
+	measureSync<T>(metricName: string, fn: () => T): T;
+}
+
+/** Type for the obsidian-metrics plugin instance */
+export interface ObsidianMetricsPlugin {
+	api: IObsidianMetricsAPI;
+}
+
+/** Augment Obsidian's workspace events to include our custom event */
+declare module 'obsidian' {
+	interface Workspace {
+		on(name: 'obsidian-metrics:ready', callback: (api: IObsidianMetricsAPI) => void): EventRef;
+		trigger(name: 'obsidian-metrics:ready', api: IObsidianMetricsAPI): void;
+	}
+}

--- a/src/ui/Banner.ts
+++ b/src/ui/Banner.ts
@@ -1,31 +1,49 @@
 "use strict";
-import { TextFileView } from "obsidian";
+import { Platform, requireApiVersion, TextFileView } from "obsidian";
 import type { CanvasView } from "src/CanvasView";
+
+export type BannerText = string | { short: string; long: string };
 
 export class Banner {
 	view: TextFileView | CanvasView;
-	text: string;
+	text: BannerText;
 	onClick: () => Promise<boolean>;
+	private useHeaderButton: boolean;
 
 	constructor(
 		view: TextFileView | CanvasView,
-		text: string,
+		text: BannerText,
 		onClick: () => Promise<boolean>,
 	) {
 		this.view = view;
 		this.text = text;
 		this.onClick = onClick;
+		// Use header button approach on mobile for Obsidian >=1.11.0 to avoid banner positioning issues
+		this.useHeaderButton = Platform.isMobile && requireApiVersion("1.11.0");
 		this.display();
+	}
+
+	private get shortText(): string {
+		return typeof this.text === "string" ? this.text : this.text.short;
+	}
+
+	private get longText(): string {
+		return typeof this.text === "string" ? this.text : this.text.long;
 	}
 
 	display() {
 		if (!this.view) return true;
 		const leafContentEl = this.view.containerEl;
-		const contentEl = this.view.containerEl.querySelector(".view-content");
 
 		if (!leafContentEl) {
 			return;
 		}
+
+		if (this.useHeaderButton) {
+			return this.displayHeaderButton();
+		}
+
+		const contentEl = this.view.containerEl.querySelector(".view-content");
 
 		// container to enable easy removal of the banner
 		let bannerBox = leafContentEl.querySelector(".system3-banner-box");
@@ -40,7 +58,7 @@ export class Banner {
 			banner = document.createElement("div");
 			banner.classList.add("system3-banner");
 			const span = banner.createSpan();
-			span.setText(this.text);
+			span.setText(this.longText);
 			banner.appendChild(span);
 			bannerBox.appendChild(banner);
 			const onClick = async () => {
@@ -54,14 +72,48 @@ export class Banner {
 		return true;
 	}
 
+	private displayHeaderButton() {
+		const leafContentEl = this.view.containerEl;
+		const viewHeaderLeftElement =
+			leafContentEl.querySelector(".view-header-left");
+
+		if (!viewHeaderLeftElement) {
+			return;
+		}
+
+		// Remove existing button if any
+		leafContentEl.querySelector(".system3-header-button")?.remove();
+
+		const button = document.createElement("button");
+		button.className = "view-header-left system3-header-button";
+		button.textContent = this.shortText;
+		button.setAttribute("aria-label", this.longText);
+		button.setAttribute("tabindex", "0");
+
+		button.addEventListener("click", async () => {
+			const destroy = await this.onClick();
+			if (destroy) {
+				this.destroy();
+			}
+		});
+
+		viewHeaderLeftElement.insertAdjacentElement("afterend", button);
+		return true;
+	}
+
 	destroy() {
 		const leafContentEl = this.view.containerEl;
 		if (!leafContentEl) {
 			return;
 		}
-		const bannerBox = leafContentEl.querySelector(".system3-banner-box");
-		if (bannerBox) {
-			bannerBox.replaceChildren();
+
+		if (this.useHeaderButton) {
+			leafContentEl.querySelector(".system3-header-button")?.remove();
+		} else {
+			const bannerBox = leafContentEl.querySelector(".system3-banner-box");
+			if (bannerBox) {
+				bannerBox.replaceChildren();
+			}
 		}
 		this.onClick = async () => true;
 		return true;

--- a/src/y-codemirror.next/LiveEditPlugin.ts
+++ b/src/y-codemirror.next/LiveEditPlugin.ts
@@ -83,7 +83,7 @@ export class LiveCMPluginValue implements PluginValue {
 		if (this.destroyed || !this.editor) {
 			return () => {};
 		}
-		
+
 		this.banner = new EmbedBanner(
 			this.sourceView,
 			this.editor.dom,
@@ -211,7 +211,10 @@ export class LiveCMPluginValue implements PluginValue {
 				}),
 			);
 		} else {
-			this.document.connect();
+			// Respect user's explicit disconnect intent
+			if (!this.document.userDisconnectedIntent) {
+				this.document.connect();
+			}
 		}
 
 		if (this.document.connected) {

--- a/styles.css
+++ b/styles.css
@@ -123,17 +123,15 @@
 }
 
 .system3-banner > span {
-	font-weight: bold;
 	display: flex;
 	flex-grow: 1;
 	font-size: var(--font-ui-medium);
 	color: var(--text-on-accent);
 	font: var(--font-interface-theme);
-	text-shadow: var(--input-shadow);
 }
 
-.system3-login-button,
-.system3-merge-button {
+.system3-header-button,
+.system3-login-button {
 	background: var(--interactive-accent) !important;
 	color: var(--text-on-accent) !important;
 	border: var(--modal-border-width) solid var(--pill-border-color-hover) !important;


### PR DESCRIPTION
## Fix to persist user disconnect intent
Ticket: see shared relay note "Disconnected note status icon shows connected after navigation".

Note: not sure how I feel about the comments--Claudia got a little excited. LMK if you want them nix'd

### The Bug
When a user explicitly disconnected a document via the UI toggle and navigated away/back, the document would auto-reconnect instead of staying disconnected.

Multiple code paths were triggering `connect()` without checking if the user had explicitly disconnected:

1. **`Document.whenReady()`** and **`Canvas.whenReady()`** - Called `connect()` unconditionally when `awaitingUpdates`
2. **`ViewHookPlugin.initialize()`** - Called `connect()` unconditionally on editor load
3. **`LiveEditPlugin` constructor** - Called `connect()` in the else branch
4. **`LiveViews.getViews()`** - Created new `LiveView` instances with `shouldConnect=true` by default, ignoring any prior user disconnect

### Solution
Added `userDisconnectedIntent` boolean flag to `Document` and `Canvas` classes:
- **Default**: `false` (documents connect by default)
- **Set to `true`**: Only via explicit user action in `toggleConnection()`
- **Set to `false`**: When user explicitly reconnects via `toggleConnection()`
- **NOT modified by**: `disconnect()`, `release()`, network issues, or connection pool limits

### Files Changed

| File | Change |
|------|--------|
| `src/Document.ts` | Added `userDisconnectedIntent` flag; check in `whenReady()` |
| `src/Canvas.ts` | Added `userDisconnectedIntent` flag; check in `whenReady()` |
| `src/LiveViews.ts` | Set flag in `toggleConnection()`; read flag in `getViews()` to pass correct `shouldConnect` |
| `src/plugins/ViewHookPlugin.ts` | Check `userDisconnectedIntent` before calling `connect()` |
| `src/y-codemirror.next/LiveEditPlugin.ts` | Check `userDisconnectedIntent` before calling `connect()` |

### Test Coverage
New test file: `__tests__/UserDisconnectedIntent.test.ts` (8 tests)
This test is limited and probably not high-value, but I got lazy going down the mocking slope. All other previous tests pass.

Tests the flag pattern in isolation:
- Default value is `false`
- Flag preserved after `disconnect()` calls
- `toggleConnection()` sets flag correctly
- **Key test**: Navigation scenario - disconnect, navigate away/back, verify stays disconnected
- Auto-connect when user never explicitly disconnected
- Auto-connect after user explicitly reconnects

### Manual QA Tests Passed (plus brute force monkey regression QA)
1. Disconnect → navigate away → navigate back → stays disconnected
2. Don't disconnect → navigate away → navigate back → auto-connects
3. Disconnect → reconnect → navigate away → navigate back → auto-connects
4. Markdown and canvas

/Aside: added to .gitignore and removed vestigial windows carriage return characters.