### PR TITLE
fix: iOS stack trace format

### DIFF
--- a/src/debug.ts
+++ b/src/debug.ts
@@ -188,7 +188,7 @@ export function curryLog(initialText: string, level: LogLevel = "log") {
 		if (debugging) {
 			const timestamp = new Date().toISOString();
 			const stack = new Error().stack;
-			const callerInfo = stack ? stack.split("\n")[2].trim() : "";
+			const callerInfo = stack?.split("\n")[2]?.trim() ?? "";
 			const serializedArgs = args.map(serializeArg).join(" ");
 
 			const logEntry: LogEntry = {


### PR DESCRIPTION
When running vConsole on Obsidian for iOS the logger can sometimes cause crashes due to index [2] not being present.