### PR TITLE
fix: Check download response status before writing file content

### DIFF
--- a/src/CAS.ts
+++ b/src/CAS.ts
@@ -51,14 +51,19 @@ export class ContentAddressedStore extends HasLogging {
 			method: "GET",
 			headers: { Authorization: `Bearer ${token.token}` },
 		});
-		if (response.status === 404) {
+		if (!response.ok) {
 			throw new Error(
-				`[${this.sharedFolder.path}] File is missing: ${syncFile.guid} ${syncFile.meta.hash} ${syncFile.meta.type}`,
+				`[${this.sharedFolder.path}] File download-url failed: ${response.status} for ${syncFile.guid} ${syncFile.meta.hash} ${syncFile.meta.type}`,
 			);
 		}
 		const responseJson = await response.json();
 		const presignedUrl = responseJson.downloadUrl;
 		const downloadResponse = await customFetch(presignedUrl);
+		if (!downloadResponse.ok) {
+			throw new Error(
+				`[${this.sharedFolder.path}] File download failed: ${downloadResponse.status} for ${syncFile.guid}`,
+			);
+		}
 		return downloadResponse.arrayBuffer();
 	}
 


### PR DESCRIPTION
Fixes #79.

`CAS.readFile()` writes the presigned URL response body to disk without checking HTTP status. If the download returns an error (e.g., 400 with body "Something went wrong: File not found"), that error text overwrites the real file. The corrupted content gets hashed and propagated to all clients via the filemeta CRDT.

## Changes

- Check `downloadResponse.ok` before returning content from `readFile()`
- Broaden the `/download-url` status check from 404-only to all non-2xx

## Impact we saw

~30 image files replaced with 36-byte text stubs across all clients in a shared folder. The relay server's file store was temporarily misconfigured, causing download errors that the plugin wrote as file content.