### PR TITLE
ci: force VM harness clone to use deploy key

### DIFF
--- a/.github/workflows/e2e-standard.yml
+++ b/.github/workflows/e2e-standard.yml
@@ -165,13 +165,7 @@ jobs:
           mkdir -p ~/.ssh
           cp ~/ci-deploy-key ~/.ssh/ci-deploy-key
           chmod 600 ~/.ssh/ci-deploy-key
-          if ! grep -q 'ci-deploy-key' ~/.ssh/config 2>/dev/null; then
-            cat >> ~/.ssh/config << 'SSHCFG'
-          Host github.com
-            IdentityFile ~/.ssh/ci-deploy-key
-            StrictHostKeyChecking accept-new
-          SSHCFG
-          fi
+          export GIT_SSH_COMMAND="ssh -i $HOME/.ssh/ci-deploy-key -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new"
 
           # Clone or update relay-plugin (public)
           if [ ! -d ~/relay-plugin ]; then
@@ -188,7 +182,10 @@ jobs:
           if [ ! -d ~/relay-harness ]; then
             git clone git@github.com:No-Instructions/relay-harness.git ~/relay-harness
           fi
-          cd ~/relay-harness && git checkout main && git pull
+          cd ~/relay-harness
+          git fetch origin
+          git checkout main
+          git pull
 
           # Install playwright test dependencies
           cd ~/relay-harness/playwright && npm install --ignore-scripts 2>/dev/null


### PR DESCRIPTION
## Summary
- fix the first real merge-hsm `E2E standard suite` failure after PR #81 merged
- stop relying on stale VM `~/.ssh/config` when cloning or updating the private `relay-harness` repo
- force the VM-side harness git operations to use the staged `ci-deploy-key` via `GIT_SSH_COMMAND`

## Root cause
The Linux VM already has `~/.ssh/config` pinned to `~/.ssh/relay-e2e-deploy`, and that key does not have access to `No-Instructions/relay-harness`. The workflow was appending a second `Host github.com` stanza, but that was not a reliable override, so the private harness clone failed inside the VM step.

## Verification
- git diff --check -- .github/workflows/e2e-standard.yml
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/e2e-standard.yml")'
- direct VM repro of the stale-key failure mode via gcloud ssh
