### PR TITLE
ci: raise Linux standard-suite timeout budget

### DIFF
--- a/.github/workflows/e2e-standard.yml
+++ b/.github/workflows/e2e-standard.yml
@@ -19,7 +19,7 @@ env:
 jobs:
   standard-test:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
 
     steps:
       - name: Auth to GCP


### PR DESCRIPTION
## Summary
- raise the Linux standard-suite job timeout from 30 minutes to 60 minutes

## Why
The full Linux run is now getting through real VM execution and into the report/upload tail, but run 24270733556 still died at the workflow's 30-minute budget. The short targeted rerun path is useful for fast proof work, but the real full suite still needs enough budget to finish.

## Evidence
- run 24270733556 started at 00:49:36Z
- run 24270733556 ended at 01:20:02Z
- step `Run standard suite on VM` was cancelled under the workflow timeout
- the upload log showed `Error: The operation was canceled.` because the job was already being terminated

## Verification
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/e2e-standard.yml")'
- git diff --check -- .github/workflows/e2e-standard.yml