### PR TITLE
ci: clear stale repo-local slots before Linux run

### DIFF
--- a/.github/workflows/e2e-standard.yml
+++ b/.github/workflows/e2e-standard.yml
@@ -207,6 +207,10 @@ jobs:
           git checkout main
           git pull
 
+          # Clear stale repo-local test instances left by canceled or crashed runs
+          echo "Clearing stale repo-local slots..."
+          ./scripts/stop-obsidian.sh >/dev/null 2>&1 || true
+
           # Install playwright test dependencies
           cd ~/relay-harness/playwright && npm install --ignore-scripts 2>/dev/null
 


### PR DESCRIPTION
## Summary
- clear stale repo-local Obsidian test instances on the Linux VM before slot claim
- do it after harness update and before the standard suite starts

## Why
Workflow run 24278289066 failed before tests with `Could only claim 0 of 1 needed slots` because all repo-local slot ports on the VM appeared occupied.