### PR TITLE
fix: restore editor context helpers

### DIFF
--- a/.github/workflows/e2e-standard.yml
+++ b/.github/workflows/e2e-standard.yml
@@ -14,16 +14,53 @@ on:
         required: false
         default: ''
 
+concurrency:
+  group: e2e-standard-linux
+  cancel-in-progress: false
+
 env:
-  VM_NAME: ${{ secrets.GCP_VM_NAME }}
   VM_ZONE: ${{ secrets.GCP_VM_ZONE }}
   GCP_PROJECT: ${{ secrets.GCP_PROJECT }}
   GCP_USE_IAP: "true"
 
 jobs:
   standard-test:
+    name: ${{ format('standard-test ({0})', matrix.shard.name) }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      max-parallel: 7
+      matrix:
+        shard:
+          - name: foundation-core
+            slug: foundation-core
+            tests: test-basic-open-close,test-folder-lifecycle,test-view-reuse-file-switching
+          - name: foundation-share
+            slug: foundation-share
+            tests: test-share-folder,test-in-note-status
+          - name: sync-state
+            slug: sync-state
+            tests: test-idle-registration,test-active-editor-sync,test-offline-banner,test-binary-free-user
+          - name: conflicts-differ
+            slug: conflicts-differ
+            tests: test-differ-resolve,test-trigger-differ,test-differ-dismissal
+          - name: conflicts-resolution
+            slug: conflicts-resolution
+            tests: test-conflict-dismiss,test-conflict-cancel,test-upgrade-no-lca-conflict
+          - name: bulk-upload
+            slug: bulk
+            tests: test-bulk-upload
+          - name: restart-heavy
+            slug: restart
+            tests: test-bases-checkbox-sync,test-obsidian-restart,test-cold-reopen-external-edit
+    env:
+      VM_NAME: ${{ format('{0}-{1}', secrets.GCP_VM_NAME, matrix.shard.slug) }}
+      SHARD_NAME: ${{ matrix.shard.name }}
+      SHARD_SLUG: ${{ matrix.shard.slug }}
+      SHARD_TESTS: ${{ matrix.shard.tests }}
+      GCP_VM_DISK_SIZE: 20GB
+      GCP_VM_DISK_TYPE: pd-standard
 
     steps:
       - name: Auth to GCP
@@ -34,7 +71,52 @@ jobs:
       - name: Setup gcloud
         uses: google-github-actions/setup-gcloud@v2
 
+      - name: Select tests for shard
+        id: select-tests
+        run: |
+          TARGETED_TESTS="${{ github.event.inputs.tests || '' }}"
+          SHARD_TESTS="${{ matrix.shard.tests }}"
+
+          select_tests() {
+            local available="$1"
+            local wanted="$2"
+            local filtered=""
+            local test match
+
+            IFS=',' read -r -a available_tests <<< "$available"
+            IFS=',' read -r -a wanted_tests <<< "$wanted"
+
+            for test in "${available_tests[@]}"; do
+              test="${test//[[:space:]]/}"
+              [ -n "$test" ] || continue
+              for match in "${wanted_tests[@]}"; do
+                match="${match//[[:space:]]/}"
+                [ -n "$match" ] || continue
+                if [ "$test" = "$match" ]; then
+                  filtered="${filtered:+$filtered,}$test"
+                  break
+                fi
+              done
+            done
+
+            printf '%s' "$filtered"
+          }
+
+          SELECTED_TESTS="$SHARD_TESTS"
+          if [ -n "$TARGETED_TESTS" ]; then
+            SELECTED_TESTS="$(select_tests "$SHARD_TESTS" "$TARGETED_TESTS")"
+          fi
+
+          if [ -n "$SELECTED_TESTS" ]; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            echo "selected_tests=$SELECTED_TESTS" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            echo "selected_tests=" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Clone relay-harness
+        if: steps.select-tests.outputs.should_run == 'true'
         run: |
           mkdir -p ~/.ssh
           echo '${{ secrets.HARNESS_DEPLOY_KEY }}' > ~/.ssh/harness-key
@@ -56,6 +138,7 @@ jobs:
           git clone git@github.com:No-Instructions/relay-harness.git ~/relay-harness
 
       - name: Ensure VM is running
+        if: steps.select-tests.outputs.should_run == 'true'
         run: |
           STATUS=$(gcloud compute instances describe "$VM_NAME" \
             --zone="$VM_ZONE" --project="$GCP_PROJECT" \
@@ -64,7 +147,9 @@ jobs:
           if [ "$STATUS" = "NOT_FOUND" ]; then
             echo "VM does not exist. Creating via harness infra scripts..."
             cd ~/relay-harness
-            GCP_PROJECT="$GCP_PROJECT" GCP_ZONE="$VM_ZONE" ./infra/gcp-linux-vm.sh create
+            GCP_PROJECT="$GCP_PROJECT" GCP_ZONE="$VM_ZONE" GCP_VM_NAME="$VM_NAME" \
+              GCP_VM_DISK_SIZE="$GCP_VM_DISK_SIZE" GCP_VM_DISK_TYPE="$GCP_VM_DISK_TYPE" \
+              ./infra/gcp-linux-vm.sh create
           elif [ "$STATUS" = "TERMINATED" ] || [ "$STATUS" = "STOPPED" ]; then
             echo "Starting stopped VM..."
             gcloud compute instances start "$VM_NAME" \
@@ -98,55 +183,87 @@ jobs:
           done
 
       - name: Provision VM credentials
+        if: steps.select-tests.outputs.should_run == 'true'
         run: |
+          scp_retry() {
+            local src="$1"
+            local dest="$2"
+            local label="$3"
+            local attempt
+
+            for attempt in $(seq 1 5); do
+              if gcloud compute scp --quiet "$src" "$VM_NAME":"$dest" \
+                --zone="$VM_ZONE" --project="$GCP_PROJECT" \
+                --tunnel-through-iap; then
+                return 0
+              fi
+              echo "Retrying $label scp ($attempt/5) ..."
+              sleep 5
+            done
+
+            echo "Failed to copy $label to VM after 5 attempts"
+            return 1
+          }
+
+          ssh_retry() {
+            local label="$1"
+            local command="$2"
+            local attempt
+
+            for attempt in $(seq 1 5); do
+              if gcloud compute ssh "$VM_NAME" --quiet \
+                --zone="$VM_ZONE" --project="$GCP_PROJECT" \
+                --tunnel-through-iap \
+                --command="$command"; then
+                return 0
+              fi
+              echo "Retrying $label ssh command ($attempt/5) ..."
+              sleep 5
+            done
+
+            echo "Failed $label ssh command after 5 attempts"
+            return 1
+          }
+
           echo '${{ secrets.GCP_SA_KEY }}' > /tmp/sa-key.json
-          gcloud compute scp --quiet /tmp/sa-key.json "$VM_NAME":~/ci-sa-key.json \
-            --zone="$VM_ZONE" --project="$GCP_PROJECT" \
-            --tunnel-through-iap 2>/dev/null
+          scp_retry /tmp/sa-key.json ~/ci-sa-key.json "service-account key"
           rm -f /tmp/sa-key.json
 
           echo '${{ secrets.HARNESS_DEPLOY_KEY }}' > /tmp/deploy-key
           chmod 600 /tmp/deploy-key
-          gcloud compute scp --quiet /tmp/deploy-key "$VM_NAME":~/ci-deploy-key \
-            --zone="$VM_ZONE" --project="$GCP_PROJECT" \
-            --tunnel-through-iap 2>/dev/null
+          scp_retry /tmp/deploy-key ~/ci-deploy-key "deploy key"
           rm -f /tmp/deploy-key
 
           # GitHub App private key for posting Check Runs
           echo '${{ secrets.E2E_APP_KEY }}' > /tmp/github-app-key.pem
           chmod 600 /tmp/github-app-key.pem
-          gcloud compute ssh "$VM_NAME" --quiet \
-            --zone="$VM_ZONE" --project="$GCP_PROJECT" \
-            --tunnel-through-iap \
-            --command="mkdir -p ~/.config/relay-e2e" 2>/dev/null
-          gcloud compute scp --quiet /tmp/github-app-key.pem "$VM_NAME":~/.config/relay-e2e/github-app-key.pem \
-            --zone="$VM_ZONE" --project="$GCP_PROJECT" \
-            --tunnel-through-iap 2>/dev/null
+          ssh_retry "relay-e2e config dir creation" "mkdir -p ~/.config/relay-e2e"
+          scp_retry /tmp/github-app-key.pem ~/.config/relay-e2e/github-app-key.pem "GitHub App key"
           rm -f /tmp/github-app-key.pem
 
           # R2 credentials for ci.system3.dev uploads
-          gcloud compute ssh "$VM_NAME" --quiet \
-            --zone="$VM_ZONE" --project="$GCP_PROJECT" \
-            --tunnel-through-iap \
-            --command="cat > ~/.config/relay-e2e/r2-env.sh << 'CREDS'
+          ssh_retry "R2 env write" "cat > ~/.config/relay-e2e/r2-env.sh << 'CREDS'
           export CI_R2_ENDPOINT='${{ secrets.CI_R2_ENDPOINT }}'
           export CI_R2_ACCESS_KEY_ID='${{ secrets.CI_R2_ACCESS_KEY_ID }}'
           export CI_R2_SECRET_ACCESS_KEY='${{ secrets.CI_R2_SECRET_ACCESS_KEY }}'
           CREDS
-          chmod 600 ~/.config/relay-e2e/r2-env.sh" 2>/dev/null
+          chmod 600 ~/.config/relay-e2e/r2-env.sh"
 
       - name: Run standard suite on VM
+        if: steps.select-tests.outputs.should_run == 'true'
         run: |
           REF="${{ github.event.inputs.ref || format('origin/{0}', github.ref_name) }}"
-          TARGETED_TESTS="${{ github.event.inputs.tests || '' }}"
+          SELECTED_TESTS="${{ steps.select-tests.outputs.selected_tests }}"
+          SHARD_SLUG_ARG="${{ matrix.shard.slug }}"
 
           gcloud compute ssh "$VM_NAME" --quiet \
             --zone="$VM_ZONE" --project="$GCP_PROJECT" \
             --tunnel-through-iap \
-            --command="bash -s -- '$REF' '$TARGETED_TESTS'" 2>/dev/null << 'REMOTE_SCRIPT'
+            --command="bash -s -- '$REF' '$SELECTED_TESTS' '$SHARD_SLUG_ARG'" 2>/dev/null << 'REMOTE_SCRIPT'
           set -eo pipefail
           REF="$1"
-          TARGETED_TESTS="$2"
+          SELECTED_TESTS="$2"
+          SHARD_SLUG="$3"
 
           # Load R2 credentials
           [ -f ~/.config/relay-e2e/r2-env.sh ] && source ~/.config/relay-e2e/r2-env.sh
@@ -219,16 +336,17 @@ jobs:
           cd ~/relay-harness
 
           TEST_EXIT=0
-          TEST_CMD=(./scripts/run-e2e-suite.sh "$REF" --upload --checks)
-          if [ -n "$TARGETED_TESTS" ]; then
-            TEST_CMD+=("--tests=$TARGETED_TESTS")
-          fi
-          "${TEST_CMD[@]}" || TEST_EXIT=$?
+          TEST_CMD=(./scripts/run-e2e-suite.sh "$REF" --upload)
+          TEST_CMD+=("--tests=$SELECTED_TESTS")
+          RELAY_RUN_EXEC_SUFFIX="$SHARD_SLUG" "${TEST_CMD[@]}" || TEST_EXIT=$?
 
           # Extract results for the GitHub Actions runner
-          LATEST=$(ls -td /tmp/test-reports/runs/*/* 2>/dev/null | head -1)
-          if [ -n "$LATEST" ] && [ -f "$LATEST/summary.json" ]; then
-            cp "$LATEST/summary.json" ~/test-summary.json
+          LATEST_SUMMARY=$(find /tmp/test-reports/runs -mindepth 3 -maxdepth 3 -type f -name summary.json -print0 2>/dev/null \
+            | xargs -0 ls -t 2>/dev/null \
+            | head -1)
+          if [ -n "$LATEST_SUMMARY" ]; then
+            LATEST="$(dirname "$LATEST_SUMMARY")"
+            cp "$LATEST_SUMMARY" ~/test-summary.json
 
             COMMIT=$(basename "$(dirname "$LATEST")")
             EXEC_ID=$(basename "$LATEST")
@@ -246,7 +364,7 @@ jobs:
           REMOTE_SCRIPT
 
       - name: Clean up VM credentials
-        if: always()
+        if: always() && steps.select-tests.outputs.should_run == 'true'
         run: |
           gcloud compute ssh "$VM_NAME" --quiet \
             --zone="$VM_ZONE" --project="$GCP_PROJECT" \
@@ -254,7 +372,7 @@ jobs:
             --command="rm -f ~/ci-sa-key.json ~/ci-deploy-key ~/.ssh/ci-deploy-key ~/.config/relay-e2e/github-app-key.pem ~/.config/relay-e2e/r2-env.sh" 2>/dev/null || true
 
       - name: Fetch results
-        if: always()
+        if: always() && steps.select-tests.outputs.should_run == 'true'
         run: |
           gcloud compute scp --quiet "$VM_NAME":~/test-summary.json ./summary.json \
             --zone="$VM_ZONE" --project="$GCP_PROJECT" \
@@ -263,18 +381,42 @@ jobs:
             --zone="$VM_ZONE" --project="$GCP_PROJECT" \
             --tunnel-through-iap 2>/dev/null || true
 
+      - name: Request shard VM stop
+        if: always() && steps.select-tests.outputs.should_run == 'true'
+        run: |
+          STATUS=$(gcloud compute instances describe "$VM_NAME" \
+            --zone="$VM_ZONE" --project="$GCP_PROJECT" \
+            --format='get(status)' 2>/dev/null || echo "NOT_FOUND")
+
+          if [ "$STATUS" = "RUNNING" ]; then
+            echo "Requesting asynchronous stop for shard VM..."
+            gcloud compute instances stop "$VM_NAME" \
+              --zone="$VM_ZONE" --project="$GCP_PROJECT" \
+              --quiet --async 2>/dev/null || true
+          else
+            echo "Skipping stop request (status: $STATUS)"
+          fi
+
       - name: Generate job summary
         if: always()
         uses: actions/github-script@v7
         with:
           script: |
             const fs = require('fs');
+            const shardName = process.env.SHARD_NAME || 'shard';
+            const shouldRun = process.env.RUN_SHARD === 'true';
+
+            if (!shouldRun) {
+              core.summary.addRaw(`## E2E standard suite results (${shardName})\n\n:warning: **SKIPPED** | no matching tests for this shard\n`);
+              await core.summary.write();
+              return;
+            }
 
             let summary, metadata;
             try {
               summary = JSON.parse(fs.readFileSync('summary.json', 'utf-8'));
             } catch {
-              core.summary.addRaw('## E2E standard suite results\n\n:x: **Failed to retrieve test results from VM**\n');
+              core.summary.addRaw(`## E2E standard suite results (${shardName})\n\n:x: **Failed to retrieve test results from VM**\n`);
               await core.summary.write();
               core.setFailed('No test results available');
               return;
@@ -307,7 +449,7 @@ jobs:
             if (s.expectedFail) parts.push(`${s.expectedFail} expected-fail`);
             if (s.unexpectedPass) parts.push(`${s.unexpectedPass} unexpected-pass`);
 
-            let md = `## E2E standard suite results\n\n`;
+            let md = `## E2E standard suite results (${shardName})\n\n`;
             md += `${verdictEmoji} **${verdictText}** | ${parts.join(', ')} | ${totalDur}s`;
             if (metadata.reportUrl) {
               md += ` | [Full Report](${metadata.reportUrl})`;
@@ -343,3 +485,5 @@ jobs:
             } else if ((s.fail || 0) > 0) {
               core.setFailed(`${s.fail} test(s) failed`);
             }
+        env:
+          RUN_SHARD: ${{ steps.select-tests.outputs.should_run }}

--- a/__tests__/merge-hsm/MergeManager.test.ts
+++ b/__tests__/merge-hsm/MergeManager.test.ts
@@ -695,43 +695,6 @@ describe('MergeManager', () => {
     });
   });
 
-  describe('setActiveDocuments', () => {
-    test('setActiveDocuments only affects HSMs in loading state', async () => {
-      // Create documents - HSMs will auto-transition to idle.synced
-      const doc1 = await createMockDocument('doc-1', 'test1.md');
-      const doc2 = await createMockDocument('doc-2', 'test2.md');
-
-      // Both should be in idle.synced (not loading)
-      expect(doc1.hsm?.state.statePath).toBe('idle.synced');
-      expect(doc2.hsm?.state.statePath).toBe('idle.synced');
-
-      // setActiveDocuments should have no effect since HSMs are not in loading state
-      const allGuids = Array.from(documents.keys());
-      manager.setActiveDocuments(new Set(['doc-1']), allGuids);
-
-      // HSMs should remain in their current states
-      expect(doc1.hsm?.state.statePath).toBe('idle.synced');
-      expect(doc2.hsm?.state.statePath).toBe('idle.synced');
-    });
-
-    test('setActiveDocuments is a no-op when destroyed', async () => {
-      const managerToDestroy = new MergeManager({
-        getVaultId: (guid) => `test-${guid}`,
-        getDocument: (guid) => documents.get(guid),
-        timeProvider,
-      });
-
-      // Reassign manager for createMockDocument to use
-      manager = managerToDestroy;
-      await createMockDocument('doc-1', 'test.md');
-
-      managerToDestroy.destroy();
-
-      // Should not throw
-      expect(() => managerToDestroy.setActiveDocuments(new Set(['doc-1']), ['doc-1'])).not.toThrow();
-    });
-  });
-
   describe('state exposure', () => {
     test('state.pendingEditorContent is undefined in idle mode', async () => {
       const doc = await createMockDocument('doc-1', 'test.md');

--- a/jest.config.js
+++ b/jest.config.js
@@ -19,7 +19,7 @@ module.exports = {
     globals: {
         "BUILD_TYPE": "production",
     },
-	transformIgnorePatterns: ["/node_modules/(?!(yjs|lib0)/)"],
+	transformIgnorePatterns: ["[\\/]node_modules[\\/](?!(yjs|lib0)[\\/])"],
 	transform: {
 		"\\.ts$": [
 			"ts-jest",
@@ -38,7 +38,7 @@ module.exports = {
 				useESM: true,
 			},
 		],
-		"node_modules/(yjs|lib0)/.+\\.js$": [
+		"node_modules[\\/](yjs|lib0)[\\/].+\\.js$": [
 			"ts-jest",
 			{
 				isolatedModules: true,

--- a/src/Canvas.ts
+++ b/src/Canvas.ts
@@ -8,6 +8,7 @@ import type { SharedFolder } from "./SharedFolder";
 import { getMimeType } from "./mimetypes";
 import { IndexeddbPersistence } from "./storage/y-indexeddb";
 import { Dependency } from "./promiseUtils";
+import { awaitOnReload } from "./reloadUtils";
 import type { Unsubscriber } from "./observable/Observable";
 import type {
 	CanvasData,
@@ -389,6 +390,10 @@ export class Canvas extends HasProvider implements IFile, HasMimeType {
 		this.unsubscribes.forEach((unsubscribe) => {
 			unsubscribe();
 		});
+		if (this._persistence) {
+			const p = this._persistence.destroy().catch(() => {});
+			awaitOnReload(p);
+		}
 		super.destroy();
 		this.ydoc.destroy();
 		this.whenSyncedPromise?.destroy();

--- a/src/CanvasPlugin.ts
+++ b/src/CanvasPlugin.ts
@@ -134,7 +134,7 @@ export class CanvasPlugin extends HasLogging {
 				// Read editor content: the embed's CM6 editor may start empty,
 				// so use the child view's data (which holds the disk content).
 				const editorContent = embedView.data ?? "";
-				document.acquireLock(editorContent).catch((error: unknown) => {
+				document.acquireLock(embedView, editorContent).catch((error: unknown) => {
 					this.error(
 						"Error acquiring lock for canvas embed:",
 						error,
@@ -144,7 +144,7 @@ export class CanvasPlugin extends HasLogging {
 				return () => {
 					this.trackedEmbedViews.delete(embedView);
 					plugin.destroy();
-					document.releaseLock();
+					document.releaseLock(embedView);
 				};
 			})(),
 		);

--- a/src/Document.ts
+++ b/src/Document.ts
@@ -5,7 +5,7 @@ import { HasProvider } from "./HasProvider";
 import { LoginManager } from "./LoginManager";
 import { S3Document, S3Folder, S3RN, S3RemoteDocument } from "./S3RN";
 import { SharedFolder } from "./SharedFolder";
-import type { TFile, Vault, TFolder } from "obsidian";
+import type { TFile, Vault, TFolder, TextFileView } from "obsidian";
 import { debounce } from "obsidian";
 import type { Unsubscriber } from "./observable/Observable";
 import { Dependency } from "./promiseUtils";
@@ -65,6 +65,7 @@ export class Document extends HasProvider implements IFile, HasMimeType {
 	 * Used to distinguish our writes from external modifications.
 	 */
 	private _isSaving: boolean = false;
+	private _lockHolders: Set<TextFileView> = new Set();
 
 	constructor(
 		path: string,
@@ -270,39 +271,37 @@ export class Document extends HasProvider implements IFile, HasMimeType {
 	 *   merge operations. Pass the content from the editor or read from disk.
 	 * @returns The MergeHSM instance, or null if HSM is not enabled
 	 */
-	async acquireLock(editorContent?: string, editorViewRef?: EditorViewRef): Promise<MergeHSM | null> {
+	async acquireLock(view: TextFileView, editorContent?: string): Promise<MergeHSM | null> {
+		this._lockHolders.add(view);
+		this.userLock = true;
+
 		const mergeManager = this.sharedFolder.mergeManager;
 		if (!mergeManager || !this._hsm) {
-			this.userLock = true; // Fallback if MergeManager/HSM not available
 			return null;
 		}
 
+		if (this._lockHolders.size > 1) {
+			return this._hsm;
+		}
+
 		try {
-			// v6: If editorContent not provided, read from disk (fallback for backward compatibility)
 			let content = editorContent;
 			if (content === undefined) {
 				const tfile = this.tfile;
 				if (tfile) {
 					content = await this.vault.read(tfile);
 				} else {
-					content = "";  // New file, no content yet
+					content = "";
 				}
 			}
 
-			// Ensure remoteDoc and provider exist before entering active mode.
-			// This wakes the document from hibernation if needed.
 			const remoteDoc = this.ensureRemoteDoc();
 			this._hsm.setRemoteDoc(remoteDoc);
 
-			// Send ACQUIRE_LOCK with editorContent to transition from idle to active.
-			// Always send (don't guard with isLoaded) because releaseLock() doesn't await
-			// unload(), so activeDocs may not be cleared when file is quickly reopened.
-			// The HSM handles duplicate ACQUIRE_LOCK gracefully (no-op if already active).
+			const editorViewRef = view as unknown as EditorViewRef;
 			this._hsm.send({ type: "ACQUIRE_LOCK", editorContent: content, editorViewRef });
 			mergeManager.markActive(this.guid);
 
-			// Create ProviderIntegration BEFORE awaiting so it can deliver
-			// PROVIDER_SYNCED during the entering phase (needed for empty-IDB flow).
 			if (!this._providerIntegration) {
 				this._providerIntegration = new ProviderIntegration(
 					this._hsm,
@@ -311,31 +310,19 @@ export class Document extends HasProvider implements IFile, HasMimeType {
 				);
 			}
 
-			// Ensure provider is connected. After idle-mode fork
-			// reconciliation, destroyIdleProviderIntegration disconnects
-			// the provider. Without reconnecting, SYNC_TO_REMOTE updates
-			// from conflict resolution are buffered but never sent.
-			// connect() is a no-op if already connected.
 			this.connect();
 
-			// Wait for HSM to reach a post-entering active state
 			await this._hsm.awaitActive();
 
-			// Guard against race: releaseLock() may have been called while we
-			// were awaiting. If so, the HSM has already transitioned back to idle
-			// and we must not keep a ProviderIntegration (it would leak).
-			if (!this.userLock && !mergeManager.isActive(this.guid)) {
+			if (this._lockHolders.size === 0 && !mergeManager.isActive(this.guid)) {
 				this._providerIntegration.destroy();
 				this._providerIntegration = null;
 				return null;
 			}
 
-			this.userLock = true; // Keep for compatibility
-
 			return this._hsm;
 		} catch (e) {
 			this.warn("[acquireLock] Failed to acquire HSM lock:", e);
-			this.userLock = true; // Fallback
 			return null;
 		}
 	}
@@ -345,19 +332,22 @@ export class Document extends HasProvider implements IFile, HasMimeType {
 	 * Transitions HSM from active back to idle mode.
 	 * Call this when editor closes (replaces userLock = false).
 	 */
-	releaseLock(): void {
-		this.userLock = false; // Keep for compatibility
+	releaseLock(view: TextFileView): void {
+		this._lockHolders.delete(view);
 
-		// Destroy ProviderIntegration (unsubscribes from events)
+		if (this._lockHolders.size > 0) {
+			return;
+		}
+
+		this.userLock = false;
+
 		if (this._providerIntegration) {
 			this._providerIntegration.destroy();
 			this._providerIntegration = null;
 		}
 
-		// Guard: sharedFolder may be null if document was orphaned (file moved out of folder)
 		const mergeManager = this.sharedFolder?.mergeManager;
 		if (mergeManager) {
-			// MergeManager.unload() sends RELEASE_LOCK and awaits IDB cleanup
 			const p = mergeManager.unload(this.guid);
 			awaitOnReload(p);
 		}
@@ -647,9 +637,19 @@ export class Document extends HasProvider implements IFile, HasMimeType {
 			unsubscribe();
 		});
 
-		// Release HSM lock if held
-		if (this._hsm) {
-			this.releaseLock();
+		// Force-release HSM lock regardless of remaining holders
+		if (this._hsm && this._lockHolders.size > 0) {
+			this._lockHolders.clear();
+			this.userLock = false;
+			if (this._providerIntegration) {
+				this._providerIntegration.destroy();
+				this._providerIntegration = null;
+			}
+			const mergeManager = this.sharedFolder?.mergeManager;
+			if (mergeManager) {
+				const p = mergeManager.unload(this.guid);
+				awaitOnReload(p);
+			}
 		}
 
 		super.destroy();

--- a/src/LiveViews.ts
+++ b/src/LiveViews.ts
@@ -13,7 +13,6 @@ import {
 import ViewActions from "src/components/ViewActions.svelte";
 import * as Y from "yjs";
 import { Document } from "./Document";
-import type { EditorViewRef } from "./merge-hsm/types";
 import type { ConnectionState } from "./HasProvider";
 import { LoginManager } from "./LoginManager";
 import NetworkStatus from "./NetworkStatus";
@@ -51,7 +50,6 @@ export function getConnectionManager(editor: EditorView): LiveViewManager | null
 	return (fileInfo as any)?.app?.plugins?.plugins?.["system3-relay"]?._liveViews ?? null;
 }
 
-const BACKGROUND_CONNECTIONS = 3;
 
 function iterateCanvasViews(
 	workspace: Workspace,
@@ -699,10 +697,8 @@ export class LiveView<ViewType extends TextFileView>
 	attach(): Promise<this> {
 		// can be called multiple times, whereas release is only ever called once
 		// Use HSM acquireLock if available, otherwise falls back to userLock internally
-		// Pass view as EditorViewRef so HSM can read the live dirty flag
-		const viewRef: EditorViewRef = this.view as unknown as EditorViewRef;
 		this.document
-			.acquireLock(undefined, viewRef)
+			.acquireLock(this.view)
 			.then(() => {
 				// Refresh ViewActions after lock acquired — HSM may have
 				// reached active.tracking during the async acquireLock.
@@ -816,7 +812,7 @@ export class LiveView<ViewType extends TextFileView>
 		this._plugin?.destroy();
 		this._plugin = undefined;
 		this.document.disconnect();
-		this.document.releaseLock();
+		this.document.releaseLock(this.view);
 	}
 
 	destroy() {
@@ -950,82 +946,11 @@ export class LiveViewManager {
 		this.sharedFolders.items().forEach((folder: SharedFolder) => {
 			folder.connect();
 		});
-		this.viewsAttachedWithConnectionPool(this.views);
+		this.viewsAttached(this.views);
 	}
 
 	docIsOpen(doc: Document): boolean {
 		return this.views.some((view) => view.document === doc);
-	}
-
-	/**
-	 * Notify MergeManagers which documents have open editors.
-	 * Groups views by their shared folder and calls setActiveDocuments() on each.
-	 * This transitions HSMs from 'loading' to the appropriate mode (idle or active).
-	 *
-	 * Per spec (Gap 8): LiveViews sends bulk update to MergeManager indicating which
-	 * documents have open editors. MergeManager fans out SET_MODE_ACTIVE to those HSMs,
-	 * and SET_MODE_IDLE to all others.
-	 */
-	private async updateMergeManagerActiveDocuments(views: S3View[]): Promise<void> {
-		// Group document GUIDs by their shared folder
-		const folderToGuids = new Map<SharedFolder, Set<string>>();
-
-		for (const view of views) {
-			const doc = view.document;
-			if (!doc) continue;
-
-			const folder = doc.sharedFolder;
-			if (!folder?.mergeManager) continue;
-
-			if (!folderToGuids.has(folder)) {
-				folderToGuids.set(folder, new Set());
-			}
-			folderToGuids.get(folder)!.add(doc.guid);
-		}
-
-		// Also discover embedded markdown files inside canvas views.
-		// Canvas nodes with type='file' have a child TextFileView whose file
-		// may belong to a shared folder. Their HSMs need active mode too.
-		for (const view of views) {
-			if (!(view instanceof RelayCanvasView)) continue;
-			const canvas = view.view.canvas;
-			if (!canvas?.nodes) continue;
-
-			for (const [, node] of canvas.nodes) {
-				const nodeData = node.getData?.();
-				// @ts-ignore — child is not typed on CanvasNode, only on CanvasNodeData
-				const child = (node as any).child ?? nodeData?.child;
-				if (!child?.file) continue;
-
-				const filePath: string = child.file.path;
-				if (!filePath.endsWith(".md")) continue;
-
-				const folder = this.sharedFolders.lookup(filePath);
-				if (!folder?.mergeManager || !folder.ready) continue;
-
-				const embeddedDoc = folder.proxy.getDoc(filePath);
-				if (!embeddedDoc) continue;
-
-				if (!folderToGuids.has(folder)) {
-					folderToGuids.set(folder, new Set());
-				}
-				folderToGuids.get(folder)!.add(embeddedDoc.guid);
-			}
-		}
-
-		// Call setActiveDocuments on each folder's MergeManager
-		for (const [folder, guids] of folderToGuids) {
-			const allGuids = Array.from(folder.files.keys());
-			folder.mergeManager.setActiveDocuments(guids, allGuids);
-		}
-
-		// Also notify folders with no active views (all HSMs should be idle)
-		for (const folder of this.sharedFolders.items()) {
-			if (!folderToGuids.has(folder) && folder.mergeManager) {
-				const allGuids = Array.from(folder.files.keys());
-				folder.mergeManager.setActiveDocuments(new Set(), allGuids);
-			}
-		}
 	}
 
 	private releaseViews(views: S3View[]) {
@@ -1171,54 +1096,6 @@ export class LiveViewManager {
 		});
 	}
 
-	private async viewsReady(views: S3View[]): Promise<LiveView<TextFileView>[]> {
-		return await Promise.all(
-			views
-				.filter(isLive)
-				.map(async (view) => view.document.whenReady().then((_) => view)),
-		);
-	}
-
-	private async viewsAttachedWithConnectionPool(
-		views: S3View[],
-		backgroundConnections: number = BACKGROUND_CONNECTIONS,
-	): Promise<S3View[]> {
-		const activeView =
-			this.workspace.getActiveViewOfType<TextFileView>(TextFileView);
-
-		let attemptedConnections = 0;
-
-		const viewHistory = views.sort(
-			(a, b) =>
-				(b.view.leaf as any).activeTime - (a.view.leaf as any).activeTime,
-		);
-		const connectedDocuments = new Set<Document>();
-		for (const view of viewHistory) {
-			if (view instanceof LiveView) {
-				if (view.view === activeView || connectedDocuments.has(view.document)) {
-					view.canConnect = true;
-					connectedDocuments.add(view.document);
-				} else if (attemptedConnections < backgroundConnections) {
-					view.canConnect = true;
-					connectedDocuments.add(view.document);
-					attemptedConnections++;
-				} else {
-					view.canConnect = false;
-				}
-			}
-		}
-
-		if (attemptedConnections > backgroundConnections) {
-			this.warn(
-				`[System 3][Relay][Live Views] connection pool (max ${backgroundConnections}): rejected connections for ${
-					attemptedConnections - backgroundConnections
-				} views`,
-			);
-		}
-
-		return this.viewsAttached(views);
-	}
-
 	private async viewsAttached(views: S3View[]): Promise<S3View[]> {
 		return await Promise.all(
 			views.map(async (view) => {
@@ -1283,10 +1160,6 @@ export class LiveViewManager {
 		}
 		const activeDocumentFolders = this.findFolders();
 
-		// Notify MergeManagers which documents have open editors (Gap 8: mode determination)
-		// This transitions HSMs from 'loading' to the appropriate mode before attach() calls acquireLock()
-		await this.updateMergeManagerActiveDocuments(views);
-
 		if (activeDocumentFolders.length === 0 && views.length === 0) {
 			logViews("Releasing Views", this.views);
 			this.releaseViews(this.views);
@@ -1308,16 +1181,10 @@ export class LiveViewManager {
 		logViews("Releasing Views", stale);
 		this.releaseViews(stale);
 		if (stale.length === 0 && ViewsetsEqual(matching, this.views)) {
-			// We can assume all views are ready.
-			const attachedViews = await this.viewsAttachedWithConnectionPool(
-				this.views,
-			);
+			const attachedViews = await this.viewsAttached(this.views);
 			logViews("Attached Views", attachedViews);
 		} else {
-			const readyViews = await this.viewsReady(matching);
-			logViews("Ready Views", readyViews);
-			const attachedViews =
-				await this.viewsAttachedWithConnectionPool(readyViews);
+			const attachedViews = await this.viewsAttached(matching);
 			logViews("Attached Views", attachedViews);
 			this.views = matching;
 		}

--- a/src/RelayDebugAPI.ts
+++ b/src/RelayDebugAPI.ts
@@ -13,6 +13,7 @@ import { IndexeddbPersistence } from './storage/y-indexeddb';
 import type { E2ERecordingBridge, E2ERecordingState } from './merge-hsm/recording';
 import { getHSMBootId, getHSMBootEntries, getRecentEntries, getSessionLogs } from './debug';
 import type { SessionLogOptions } from './debug';
+import { getRecentPromises } from './trackPromise';
 
 // =============================================================================
 // Types
@@ -298,6 +299,10 @@ export interface RelayDebugGlobal {
    * `isRecoveryMode` and routes to two-way merge.
    */
   clearLca: (path: string) => Promise<void>;
+
+  // -- Promise tracking --
+  getPendingPromises: () => { label: string; ageMs: number; owner?: string }[];
+  getRecentPromises: () => { label: string; created: number; settledAt: number; state: "fulfilled" | "rejected"; owner?: string }[];
 }
 
 // =============================================================================
@@ -431,6 +436,8 @@ export class RelayDebugAPI {
       openDiffView: async (path) => this.sendConflictEvent(path, { type: 'OPEN_DIFF_VIEW' }),
       cancelDiffView: async (path) => this.sendConflictEvent(path, { type: 'CANCEL' }),
       clearLca: async (path) => this.clearLca(path),
+      getPendingPromises: () => this.plugin?.promises?.getPending() ?? [],
+      getRecentPromises: () => getRecentPromises(),
 
       setEditorContent: (content: string) => {
         const editor = (this.plugin?.app as any)?.workspace?.activeEditor?.editor;

--- a/src/ShareLinkPlugin.ts
+++ b/src/ShareLinkPlugin.ts
@@ -1,10 +1,10 @@
 import { Annotation, ChangeSet } from "@codemirror/state";
 import { EditorView, ViewPlugin } from "@codemirror/view";
 import type { PluginValue } from "@codemirror/view";
-import { TextFileView } from "obsidian";
-import { LiveView, LiveViewManager, getConnectionManager } from "./LiveViews";
 import { hasKey, updateFrontMatter } from "./Frontmatter";
 import { diffChars } from "diff";
+import { Document } from "./Document";
+import { getSharedFolders, getEditorFile } from "./editorContext";
 
 export const shareLinkAnnotation = Annotation.define();
 
@@ -53,42 +53,46 @@ function diffToChangeSet(originalText: string, newText: string): ChangeSet {
 
 export class ShareLinkPluginValue implements PluginValue {
 	editor: EditorView;
-	view?: LiveView<TextFileView>;
-	connectionManager: LiveViewManager;
+	document?: Document;
 
 	constructor(editor: EditorView) {
 		this.editor = editor;
-		this.connectionManager = getConnectionManager(this.editor)!;
-		this.view = this.connectionManager.findView(editor);
-		this.editor = editor;
-		if (this.view) {
-			const hsm = this.view.document?.hsm;
+		this.document = this.resolveDocument();
+		if (this.document) {
+			const hsm = this.document.hsm;
 			if (!hsm?.awaitState) return;
 			hsm.awaitState((s) => s.startsWith("active.")).then(async () => {
-				const hasKnownPeers = await this.view?.document?.hasKnownPeers();
-				if (this.view?.document?.text || !hasKnownPeers) {
+				const hasKnownPeers = await this.document?.hasKnownPeers();
+				if (this.document?.text || !hasKnownPeers) {
 					this.updateFrontMatter();
 				}
 			});
 		}
 	}
 
+	private resolveDocument(): Document | undefined {
+		const file = getEditorFile(this.editor);
+		if (!file) return undefined;
+		const sharedFolders = getSharedFolders(this.editor);
+		if (!sharedFolders) return undefined;
+		const folder = sharedFolders.lookup(file.path);
+		if (!folder) return undefined;
+		return folder.proxy.getDoc(file.path);
+	}
+
 	updateFrontMatter() {
-		if (!(this.view instanceof LiveView)) {
+		if (!this.document) {
 			return;
 		}
-		if (!this.view || !this.view.shouldConnect) {
-			return;
-		}
-		if (this.view.document.localText != this.editor.state.doc.toString()) {
+		if (this.document.localText != this.editor.state.doc.toString()) {
 			return;
 		}
 		const text = this.editor.state.doc.toString();
-		const shareLink = `https://ydoc.live/${this.view.document.guid}`;
+		const shareLink = `https://ydoc.live/${this.document.guid}`;
 		const withShareLink = updateFrontMatter(text, {
 			shareLink: shareLink,
 		});
-		if (!(text || this.view.document.localText)) {
+		if (!(text || this.document.localText)) {
 			// document is empty
 			this.editor.dispatch({
 				changes: { from: 0, insert: withShareLink },

--- a/src/SharedFolder.ts
+++ b/src/SharedFolder.ts
@@ -392,12 +392,6 @@ export class SharedFolder extends HasProvider {
 				this.addLocalDocs();
 				this.syncFileTree();
 
-				// Transition all HSMs to idle mode since no editor is open yet.
-				// HSMs start in 'loading', then receive SET_MODE_IDLE from MergeManager.
-				if (this.mergeManager) {
-					const allGuids = Array.from(this.files.keys());
-					this.mergeManager.setActiveDocuments(new Set(), allGuids);
-				}
 			}
 		});
 
@@ -678,11 +672,7 @@ export class SharedFolder extends HasProvider {
 					});
 				}
 			} catch (e) {
-				// File might have been deleted - ignore
-				this.debug?.(
-					`[poll] Failed to read disk state for ${guid}:`,
-					e,
-				);
+				// File might have been deleted
 			}
 
 			// Connect forked documents awaiting provider sync

--- a/src/components/PluginSettings.svelte
+++ b/src/components/PluginSettings.svelte
@@ -349,10 +349,10 @@
 		max-height: var(--modal-max-height);
 		position: relative;
 	}
-	.system3-announcement-banner {
+	:global(.system3-announcement-banner) {
 		padding-left: 48px !important;
 	}
-	.system3-announcement {
+	:global(.system3-announcement) {
 		color: var(--text-on-accent);
 	}
 </style>

--- a/src/editorContext.ts
+++ b/src/editorContext.ts
@@ -1,0 +1,25 @@
+import { EditorView } from "@codemirror/view";
+import { editorInfoField, type App, type TFile } from "obsidian";
+import type Live from "./main";
+import type { SharedFolders } from "./SharedFolder";
+
+function getEditorInfo(editor: EditorView): any | null {
+	return editor.state.field(editorInfoField, false) ?? null;
+}
+
+export function getApp(editor: EditorView): App | null {
+	return (getEditorInfo(editor)?.app as App | undefined) ?? null;
+}
+
+export function getRelayPlugin(editor: EditorView): Live | null {
+	const app = getApp(editor);
+	return (app?.plugins?.plugins?.["system3-relay"] as Live | undefined) ?? null;
+}
+
+export function getEditorFile(editor: EditorView): TFile | null {
+	return (getEditorInfo(editor)?.file as TFile | undefined) ?? null;
+}
+
+export function getSharedFolders(editor: EditorView): SharedFolders | null {
+	return getRelayPlugin(editor)?.sharedFolders ?? null;
+}

--- a/src/editorContext.ts
+++ b/src/editorContext.ts
@@ -3,6 +3,12 @@ import { editorInfoField, type App, type TFile } from "obsidian";
 import type Live from "./main";
 import type { SharedFolders } from "./SharedFolder";
 
+type AppWithPluginRegistry = App & {
+	plugins?: {
+		plugins?: Record<string, unknown>;
+	};
+};
+
 function getEditorInfo(editor: EditorView): any | null {
 	return editor.state.field(editorInfoField, false) ?? null;
 }
@@ -12,7 +18,7 @@ export function getApp(editor: EditorView): App | null {
 }
 
 export function getRelayPlugin(editor: EditorView): Live | null {
-	const app = getApp(editor);
+	const app = getApp(editor) as AppWithPluginRegistry | null;
 	return (app?.plugins?.plugins?.["system3-relay"] as Live | undefined) ?? null;
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -44,6 +44,7 @@ import NetworkStatus from "./NetworkStatus";
 import { RelayManager } from "./RelayManager";
 import { DefaultTimeProvider, type TimeProvider } from "./TimeProvider";
 import { auditTeardown } from "./observable/Observable";
+import { PromiseTracker, setActiveTracker, trackPromise } from "./trackPromise";
 import { Plugin } from "obsidian";
 
 import {
@@ -148,6 +149,7 @@ export default class Live extends Plugin {
 	repo = REPOSITORY;
 	hashStore!: ContentAddressedFileStore;
 	private _hsmStore!: HSMStore;
+	promises = new PromiseTracker();
 
 	enableDebugging(save?: boolean) {
 		setDebugging(true);
@@ -358,6 +360,17 @@ export default class Live extends Plugin {
 		this.register(() => {
 			this.timeProvider.destroy();
 		});
+
+		setActiveTracker(this.promises);
+		this.promises.setDefaultOwner(`plugin:${this._instanceId}`);
+
+		let onloadComplete!: () => void;
+		trackPromise(
+			`plugin:onload:${this._instanceId}`,
+			new Promise<void>((resolve) => {
+				onloadComplete = resolve;
+			}),
+		);
 
 		const logFilePath = normalizePath(
 			`${this.app.vault.configDir}/plugins/${this.manifest.id}/relay.log`,
@@ -790,6 +803,7 @@ export default class Live extends Plugin {
 			this.setup();
 			this._liveViews.refresh("init");
 			this.loadTime = moment.now() - start;
+			onloadComplete();
 		});
 	}
 
@@ -1377,6 +1391,9 @@ export default class Live extends Plugin {
 	onunload() {
 		this._metadataListeners.clear();
 		this._metadataEventRef = null;
+		setActiveTracker(null);
+		this.promises.destroy();
+		this.promises = null as any;
 
 		// Clean up debug API globals
 		this.relayDebugAPI?.destroy();
@@ -1428,7 +1445,7 @@ export default class Live extends Plugin {
 
 		// Flush pending HSM writes and close the database after SharedFolders
 		// are destroyed (no more writes will be queued).
-		awaitOnReload(this._hsmStore?.destroy());
+		awaitOnReload(this._hsmStore?.destroy(), `plugin:teardown:hsmStore.destroy:${this._instanceId}`);
 		this._hsmStore = null as any;
 
 		this.settingsTab?.destroy();

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,6 +12,8 @@ import {
 	requireApiVersion,
 	Modal,
 	moment,
+	type CachedMetadata,
+	type EventRef,
 } from "obsidian";
 import { Platform } from "obsidian";
 import { relative } from "path-browserify";
@@ -139,6 +141,8 @@ export default class Live extends Plugin {
 	warn!: (...args: unknown[]) => void;
 	error!: (...args: unknown[]) => void;
 	private _liveViews!: LiveViewManager;
+	private _metadataListeners: Map<TFile, (data: string, cache: CachedMetadata) => void> = new Map();
+	private _metadataEventRef: EventRef | null = null;
 	fileDiffMergeWarningKey = "file-diff-merge-warning";
 	version = GIT_TAG;
 	repo = REPOSITORY;
@@ -626,6 +630,11 @@ export default class Live extends Plugin {
 		if (!this.loginManager.setup()) {
 			new Notice("Please sign in to use relay");
 		}
+
+		this._metadataEventRef = this.app.metadataCache.on("changed", (tfile: TFile, data: string, cache: CachedMetadata) => {
+			this._metadataListeners.get(tfile)?.(data, cache);
+		});
+		this.registerEvent(this._metadataEventRef);
 
 		this.app.workspace.onLayoutReady(() => {
 			this.sharedFolders.load();
@@ -1357,7 +1366,18 @@ export default class Live extends Plugin {
 		}
 	}
 
+	onMeta(tfile: TFile, cb: (data: string, cache: CachedMetadata) => void) {
+		this._metadataListeners.set(tfile, cb);
+	}
+
+	offMeta(tfile: TFile) {
+		this._metadataListeners.delete(tfile);
+	}
+
 	onunload() {
+		this._metadataListeners.clear();
+		this._metadataEventRef = null;
+
 		// Clean up debug API globals
 		this.relayDebugAPI?.destroy();
 		this.relayDebugAPI = null as any;

--- a/src/markdownView/InvalidLinkExtension.ts
+++ b/src/markdownView/InvalidLinkExtension.ts
@@ -7,14 +7,10 @@ import {
 	type DecorationSet,
 } from "@codemirror/view";
 import { WidgetType } from "@codemirror/view";
-import { TextFileView } from "obsidian";
-import {
-	LiveView,
-	LiveViewManager,
-	getConnectionManager,
-} from "../LiveViews";
 import { curryLog } from "src/debug";
-import type { App, CachedMetadata } from "obsidian";
+import type { App, CachedMetadata, TFile } from "obsidian";
+import { Document } from "../Document";
+import { getApp, getSharedFolders, getEditorFile, getRelayPlugin } from "../editorContext";
 
 export const invalidLinkSyncAnnotation = Annotation.define();
 
@@ -44,16 +40,15 @@ export class InvalidLinkPluginValue {
 	app?: App;
 	metadata: Map<number, CacheLink>;
 	editor: EditorView;
-	view?: LiveView<TextFileView>;
-	connectionManager?: LiveViewManager;
+	document?: Document;
 	decorationAnchors: number[];
 	decorations: DecorationSet;
 	cb: (data: string, cache: CachedMetadata) => void;
 	log: (message: string) => void = (message: string) => {};
+	private subscribedTFile?: TFile;
 
 	constructor(editor: EditorView) {
 		this.editor = editor;
-		this.connectionManager = getConnectionManager(this.editor) ?? undefined;
 		this.decorations = Decoration.none;
 		this.decorationAnchors = [];
 		this.metadata = new Map();
@@ -65,45 +60,48 @@ export class InvalidLinkPluginValue {
 			});
 		};
 
-		if (!this.connectionManager) {
-			curryLog(
-				"[InvalidLinkPluginValue]",
-				"warn",
-			)("ConnectionManager not found in InvalidLinkPlugin");
-			return;
-		}
-		this.app = this.connectionManager.app;
-		this.view = this.connectionManager.findView(editor);
+		this.app = getApp(this.editor) ?? undefined;
+		this.document = this.resolveDocument();
 
-		if (!this.view) {
+		if (!this.document) {
 			return;
 		}
 
 		this.log = curryLog(
-			`[InvalidLinkPluginValue][${this.view.view.file?.path}]`,
+			`[InvalidLinkPluginValue][${this.document.path}]`,
 			"debug",
 		);
 		this.log("created");
 
-		if (this.view.document) {
-			const hsm = this.view.document.hsm;
-			if (!hsm?.awaitState) return;
-			hsm.awaitState((s) => s.startsWith("active.")).then(() => {
-				const tfile = this.view?.document?.getTFile();
-				if (this.connectionManager && this.app && this.editor && tfile) {
-					this.connectionManager.onMeta(tfile, this.cb);
-					const fileCache = this.app.metadataCache.getFileCache(tfile);
-					if (fileCache) {
-						this.updateFromMetadata(fileCache);
-						this.editor.dispatch({
-							effects: metadataChangeEffect.of(null),
-						});
-					}
-				} else {
-					this.log("unable to subscribe to metadata updates");
+		const hsm = this.document.hsm;
+		if (!hsm?.awaitState) return;
+		hsm.awaitState((s) => s.startsWith("active.")).then(() => {
+			const tfile = this.document?.getTFile();
+			const plugin = getRelayPlugin(this.editor);
+			if (plugin && this.app && this.editor && tfile) {
+				plugin.onMeta(tfile, this.cb);
+				this.subscribedTFile = tfile;
+				const fileCache = this.app.metadataCache.getFileCache(tfile);
+				if (fileCache) {
+					this.updateFromMetadata(fileCache);
+					this.editor.dispatch({
+						effects: metadataChangeEffect.of(null),
+					});
 				}
-			});
-		}
+			} else {
+				this.log("unable to subscribe to metadata updates");
+			}
+		});
+	}
+
+	private resolveDocument(): Document | undefined {
+		const file = getEditorFile(this.editor);
+		if (!file) return undefined;
+		const sharedFolders = getSharedFolders(this.editor);
+		if (!sharedFolders) return undefined;
+		const folder = sharedFolders.lookup(file.path);
+		if (!folder) return undefined;
+		return folder.proxy.getDoc(file.path);
 	}
 
 	findInternalLinks(view: EditorView) {
@@ -142,25 +140,19 @@ export class InvalidLinkPluginValue {
 	}
 
 	updateFromMetadata(cache: CachedMetadata) {
-		if (this.connectionManager) {
-			this.view = this.connectionManager.findView(this.editor);
-		}
-		if (!this.view || !this.view.document || !this.app) return;
-		if (!this.view?.document?.sharedFolder) {
-			return;
-		}
-		if (!this.view?.document?.tfile) {
-			return;
-		}
+		this.document = this.resolveDocument();
+		if (!this.document || !this.app) return;
+		if (!this.document.sharedFolder) return;
+		if (!this.document.tfile) return;
 		const cacheLinks = new Map();
 		for (const link of cache?.links || []) {
 			const linkedFile = this.app.metadataCache.getFirstLinkpathDest(
 				link.link,
-				this.view.document.path,
+				this.document.path,
 			);
 			if (
 				linkedFile &&
-				!this.view.document.sharedFolder.checkPath(linkedFile.path)
+				!this.document.sharedFolder.checkPath(linkedFile.path)
 			) {
 				cacheLinks.set(link.position.start.offset, {
 					from: link.position.start.offset,
@@ -173,11 +165,11 @@ export class InvalidLinkPluginValue {
 		for (const embed of cache?.embeds || []) {
 			const linkedFile = this.app.metadataCache.getFirstLinkpathDest(
 				embed.link,
-				this.view.document.path,
+				this.document.path,
 			);
 			if (
 				linkedFile &&
-				!this.view.document.sharedFolder.checkPath(linkedFile.path)
+				!this.document.sharedFolder.checkPath(linkedFile.path)
 			) {
 				cacheLinks.set(embed.position.start.offset, {
 					from: embed.position.start.offset,
@@ -206,19 +198,10 @@ export class InvalidLinkPluginValue {
 	}
 
 	updateFromEditor(update: ViewUpdate) {
-		// The metadata cache is slower to update than the document.
-		// We use the cache to get link information, but rely on the document links for
-		// position information to avoid any delays or positioning bugs.
-		if (this.connectionManager) {
-			this.view = this.connectionManager.findView(this.editor);
-		}
-		if (!this.view || !this.view.document || !this.app) return;
-		if (!this.view?.document?.sharedFolder) {
-			return;
-		}
-		if (!this.view?.document?.tfile) {
-			return;
-		}
+		this.document = this.resolveDocument();
+		if (!this.document || !this.app) return;
+		if (!this.document.sharedFolder) return;
+		if (!this.document.tfile) return;
 
 		const invalidAnchors: number[] = [];
 		const cacheLinks = new Map(this.metadata);
@@ -226,7 +209,6 @@ export class InvalidLinkPluginValue {
 		for (const link of editorLinks) {
 			let _cacheLink = null;
 			for (const [cacheFrom, cacheLink] of cacheLinks) {
-				// Use metadata from link cache based on any overlap.
 				if (link.from <= cacheLink.to && link.to >= cacheLink.from) {
 					_cacheLink = cacheLink;
 					cacheLinks.delete(cacheFrom);
@@ -238,11 +220,11 @@ export class InvalidLinkPluginValue {
 			}
 			const linkedFile = this.app.metadataCache.getFirstLinkpathDest(
 				_cacheLink.link,
-				this.view.document.path,
+				this.document.path,
 			);
 			const isInvalid =
 				linkedFile &&
-				!this.view.document.sharedFolder.checkPath(linkedFile.path);
+				!this.document.sharedFolder.checkPath(linkedFile.path);
 			if (isInvalid) {
 				invalidAnchors.push(link.from);
 			}
@@ -287,11 +269,12 @@ export class InvalidLinkPluginValue {
 	}
 
 	destroy() {
-		if (this.connectionManager && this.view?.document?.tfile) {
-			this.connectionManager.offMeta(this.view.document.tfile);
+		if (this.subscribedTFile) {
+			const plugin = getRelayPlugin(this.editor);
+			plugin?.offMeta(this.subscribedTFile);
+			this.subscribedTFile = undefined;
 		}
-		this.connectionManager = null as any;
-		this.view = undefined;
+		this.document = undefined;
 		this.metadata.clear();
 		this.metadata = null as any;
 		this.editor = null as any;

--- a/src/merge-hsm/MergeManager.ts
+++ b/src/merge-hsm/MergeManager.ts
@@ -776,49 +776,6 @@ export class MergeManager {
   }
 
   /**
-   * Set which documents have open editors.
-   * Called by LiveViews after scanning the workspace.
-   *
-   * - Documents in activeGuids: HSM receives SET_MODE_ACTIVE
-   * - Documents NOT in activeGuids: HSM receives SET_MODE_IDLE
-   *
-   * For HSMs in `loading` state, sends mode determination events.
-   * Also detects HSMs stuck in `active.*` mode without a corresponding
-   * open editor and sends RELEASE_LOCK to recover them to idle.
-   *
-   * @param activeGuids - GUIDs of documents with open editors
-   * @param allGuids - All document GUIDs to iterate (required since Document owns HSM)
-   */
-  setActiveDocuments(activeGuids: Set<string>, allGuids: string[]): void {
-    if (this.destroyed) return;
-
-    for (const guid of allGuids) {
-      const doc = this._getDocument(guid);
-      const hsm = doc?.hsm;
-      if (!hsm) continue;
-
-      const statePath = hsm.state.statePath;
-
-      if (statePath === 'loading') {
-        // Skip HSMs with an in-flight async load — they will receive
-        // SET_MODE_IDLE when the load completes in createHSM.
-        if (this._pendingLoads.has(guid)) continue;
-        if (activeGuids.has(guid)) {
-          hsm.send({ type: 'SET_MODE_ACTIVE' });
-        } else {
-          hsm.send({ type: 'SET_MODE_IDLE' });
-        }
-      } else if (statePath.startsWith('active.') && !activeGuids.has(guid) && !this.activeDocs.has(guid)) {
-        // HSM is in active mode but no editor is open and MergeManager doesn't
-        // consider it active. This can happen when a stale ACQUIRE_LOCK arrives
-        // (e.g., from a race between async acquireLock and sync releaseLock).
-        // Send RELEASE_LOCK to recover the HSM to idle mode.
-        hsm.send({ type: 'RELEASE_LOCK' });
-      }
-    }
-  }
-
-  /**
    * Release lock on an HSM, transitioning back to idle mode.
    * The HSM stays alive and continues processing events.
    * Waits for IndexedDB writes to complete before returning.

--- a/src/merge-hsm/integration/HSMEditorPlugin.ts
+++ b/src/merge-hsm/integration/HSMEditorPlugin.ts
@@ -15,8 +15,7 @@
 
 import { ViewPlugin, EditorView, ViewUpdate } from "@codemirror/view";
 import type { PluginValue } from "@codemirror/view";
-import { editorInfoField } from "obsidian";
-import { getConnectionManager } from "../../LiveViews";
+import { getSharedFolders, getEditorFile } from "../../editorContext";
 import { Document } from "../../Document";
 import { CM6Integration } from "./CM6Integration";
 import { ySyncAnnotation } from "./annotations";
@@ -68,14 +67,13 @@ class HSMEditorPluginValue implements PluginValue {
    * Returns null if the file isn't in a shared folder.
    */
   private resolveCurrentDocument(): Document | null {
-    const connectionManager = getConnectionManager(this.editor);
-    if (!connectionManager) return null;
+    const sharedFolders = getSharedFolders(this.editor);
+    if (!sharedFolders) return null;
 
-    const fileInfo = this.editor.state.field(editorInfoField, false);
-    const file = fileInfo?.file;
+    const file = getEditorFile(this.editor);
     if (!file) return null;
 
-    const folder = connectionManager.sharedFolders.lookup(file.path);
+    const folder = sharedFolders.lookup(file.path);
     if (!folder) return null;
 
     return folder.proxy.getDoc(file.path) as Document;
@@ -87,9 +85,6 @@ class HSMEditorPluginValue implements PluginValue {
   initializeIfReady(): boolean {
     if (this.cm6Integration) return true;
     if (this.destroyed) return false;
-
-    const connectionManager = getConnectionManager(this.editor);
-    if (!connectionManager) return false;
 
     // Detect embedded canvas editors (no MarkdownView wrapper, no auto-save)
     const sourceView = this.editor.dom.closest(".markdown-source-view");
@@ -105,8 +100,7 @@ class HSMEditorPluginValue implements PluginValue {
     // When multiple SharedFolders have files with the same relative path
     // (e.g., multiple e2e-fixture-* folders each with /test-1.md),
     // we must ensure we're connecting to the correct HSM.
-    const fileInfo = this.editor.state.field(editorInfoField, false);
-    const editorFile = fileInfo?.file;
+    const editorFile = getEditorFile(this.editor);
 
     // Verify the Document's TFile matches the editor's TFile
     const documentTFile = this.document.tfile;

--- a/src/reloadUtils.ts
+++ b/src/reloadUtils.ts
@@ -1,11 +1,17 @@
 "use strict";
 
+import { trackPromise } from "./trackPromise";
+
 /**
  * Register a promise to be awaited before plugin re-enable during reload.
  * No-op during normal Obsidian unload (app._reloadAwait will be undefined).
+ *
+ * Optional `label` tracks the promise in the active PromiseTracker so stuck
+ * teardown work can be correlated with the instance that registered it.
  */
-export function awaitOnReload(p: Promise<void>): void {
+export function awaitOnReload(p: Promise<void>, label?: string): void {
+	const tracked = label ? trackPromise(label, p) : p;
 	if (typeof window !== 'undefined') {
-		(window as any).app?._reloadAwait?.push(p);
+		(window as any).app?._reloadAwait?.push(tracked);
 	}
 }

--- a/src/trackPromise.ts
+++ b/src/trackPromise.ts
@@ -1,0 +1,94 @@
+declare const BUILD_TYPE: string;
+
+interface TrackedEntry {
+  label: string;
+  created: number;
+  owner?: string;
+}
+
+export interface CompletedEntry {
+  label: string;
+  created: number;
+  settledAt: number;
+  state: "fulfilled" | "rejected";
+  owner?: string;
+}
+
+// Module-level ring buffer of recent completions. Survives plugin reload so
+// completed promises from a prior instance remain inspectable.
+const RECENT_CAPACITY = 100;
+const _recent: CompletedEntry[] = [];
+
+function recordSettled(entry: TrackedEntry, state: "fulfilled" | "rejected"): void {
+  _recent.push({
+    label: entry.label,
+    created: entry.created,
+    settledAt: Date.now(),
+    state,
+    owner: entry.owner,
+  });
+  if (_recent.length > RECENT_CAPACITY) {
+    _recent.shift();
+  }
+}
+
+export class PromiseTracker {
+  private tracked = new Map<number, TrackedEntry>();
+  private nextId = 0;
+  private defaultOwner?: string;
+
+  constructor(defaultOwner?: string) {
+    this.defaultOwner = defaultOwner;
+  }
+
+  setDefaultOwner(owner: string | undefined): void {
+    this.defaultOwner = owner;
+  }
+
+  track<T>(label: string, p: Promise<T>, owner?: string): Promise<T> {
+    if (BUILD_TYPE !== "debug") return p;
+    const id = this.nextId++;
+    const entry: TrackedEntry = {
+      label,
+      created: Date.now(),
+      owner: owner ?? this.defaultOwner,
+    };
+    this.tracked.set(id, entry);
+    p.then(
+      () => {
+        if (this.tracked.delete(id)) recordSettled(entry, "fulfilled");
+      },
+      () => {
+        if (this.tracked.delete(id)) recordSettled(entry, "rejected");
+      },
+    );
+    return p;
+  }
+
+  getPending(): { label: string; ageMs: number; owner?: string }[] {
+    const now = Date.now();
+    return [...this.tracked.values()].map((v) => ({
+      label: v.label,
+      ageMs: now - v.created,
+      owner: v.owner,
+    }));
+  }
+
+  destroy(): void {
+    this.tracked.clear();
+  }
+}
+
+let _active: PromiseTracker | null = null;
+
+export function setActiveTracker(tracker: PromiseTracker | null): void {
+  _active = tracker;
+}
+
+export function trackPromise<T>(label: string, p: Promise<T>, owner?: string): Promise<T> {
+  return _active ? _active.track(label, p, owner) : p;
+}
+
+export function getRecentPromises(): CompletedEntry[] {
+  return [..._recent];
+}

--- a/src/y-codemirror.next/LiveNodePlugin.ts
+++ b/src/y-codemirror.next/LiveNodePlugin.ts
@@ -5,22 +5,18 @@
 import type { ChangeSpec } from "@codemirror/state";
 import { EditorView, ViewUpdate, ViewPlugin } from "@codemirror/view";
 import type { PluginValue } from "@codemirror/view";
-import {
-	LiveViewManager,
-	RelayCanvasView,
-	getConnectionManager,
-} from "../LiveViews";
 import { YText, YTextEvent, Transaction } from "yjs/dist/src/internals";
 import { curryLog } from "src/debug";
 import type { CanvasNodeData } from "src/CanvasView";
+import { isCanvas, type Canvas } from "../Canvas";
+import { getSharedFolders } from "../editorContext";
 
 // Import from shared location
 import { ySyncAnnotation } from "../merge-hsm/integration/annotations";
 
 export class LiveNodePluginValue implements PluginValue {
 	editor: EditorView;
-	view?: RelayCanvasView;
-	connectionManager?: LiveViewManager;
+	canvas?: Canvas;
 	initialSet = false;
 	private destroyed = false;
 	_observer?: (event: YTextEvent, tr: Transaction) => void;
@@ -42,8 +38,24 @@ export class LiveNodePluginValue implements PluginValue {
 		return this.node;
 	}
 
+	private resolveCanvas(): Canvas | undefined {
+		const state = (this.editor.state as any).values.find((state: any) => {
+			if (state && state.node) return state.node;
+		});
+		if (!state) return;
+		const canvasFile = state.node.canvas?.file;
+		if (!canvasFile) return;
+		const sharedFolders = getSharedFolders(this.editor);
+		if (!sharedFolders) return;
+		const folder = sharedFolders.lookup(canvasFile.path);
+		if (!folder) return;
+		const file = folder.getFile(canvasFile);
+		if (file && isCanvas(file)) return file;
+		return;
+	}
+
 	private getYText(): YText | undefined {
-		this.view = this.connectionManager?.findCanvas(this.editor);
+		this.canvas = this.resolveCanvas();
 
 		const state = (this.editor.state as any).values.find((state: any) => {
 			if (state && state.node) return state.node;
@@ -56,31 +68,30 @@ export class LiveNodePluginValue implements PluginValue {
 			this._ytext?.unobserve(this.observer);
 		}
 		this.node = state.node;
-		return this.view?.canvas.textNode(state.node);
+		return this.canvas?.textNode(state.node);
 	}
 
 	constructor(editor: EditorView) {
 		this.editor = editor;
-		this.connectionManager = getConnectionManager(this.editor) ?? undefined;
-		this.view = this.connectionManager?.findCanvas(this.editor);
+		this.canvas = this.resolveCanvas();
 		this.node = this.getNode();
 		this._ytext = this.getYText();
 		if (!this._ytext) {
 			return;
 		}
-		if (!this.view) {
+		if (!this.canvas) {
 			return;
 		}
 		this.log = curryLog(
-			`[LiveNodePluginValue][${this.view.canvas.path}#${this.node?.id}]`,
+			`[LiveNodePluginValue][${this.canvas.path}#${this.node?.id}]`,
 			"log",
 		);
 		this.warn = curryLog(
-			`[LiveNodePluginValue][${this.view.canvas.path}#${this.node?.id}]`,
+			`[LiveNodePluginValue][${this.canvas.path}#${this.node?.id}]`,
 			"warn",
 		);
 		this.debug = curryLog(
-			`[LiveNodePluginValue][${this.view.canvas.path}#${this.node?.id}]`,
+			`[LiveNodePluginValue][${this.canvas.path}#${this.node?.id}]`,
 			"debug",
 		);
 		this.debug("created");
@@ -117,7 +128,7 @@ export class LiveNodePluginValue implements PluginValue {
 						pos += d.retain;
 					}
 				}
-				if (this.view?.canvas) {
+				if (this.canvas) {
 					editor.dispatch({
 						changes,
 						annotations: [ySyncAnnotation.of(this.editor)],
@@ -174,8 +185,7 @@ export class LiveNodePluginValue implements PluginValue {
 		if (this.observer) {
 			this._ytext?.unobserve(this.observer);
 		}
-		this.connectionManager = null as any;
-		this.view = undefined;
+		this.canvas = undefined;
 		this._ytext = undefined;
 		this.editor = null as any;
 	}

--- a/src/y-codemirror.next/RemoteSelections.ts
+++ b/src/y-codemirror.next/RemoteSelections.ts
@@ -16,17 +16,11 @@ import {
 
 import type { PluginValue, DecorationSet } from "@codemirror/view";
 
-import {
-	LiveViewManager,
-	LiveView,
-	getConnectionManager,
-} from "../LiveViews";
-
 import * as Y from "yjs";
 import { Awareness } from "y-protocols/awareness.js";
 import { curryLog } from "src/debug";
-import { TextFileView, editorInfoField } from "obsidian";
 import { Document } from "../Document";
+import { getSharedFolders, getEditorFile } from "../editorContext";
 
 export const yRemoteSelectionsTheme = EditorView.baseTheme({
 	".cm-ySelection": {},
@@ -160,8 +154,6 @@ type AwarenessChangeHandler = (
 
 export class YRemoteSelectionsPluginValue implements PluginValue {
 	editor: EditorView;
-	connectionManager?: LiveViewManager;
-	view?: LiveView<TextFileView>;
 	decorations: DecorationSet;
 	_awareness?: Awareness;
 	_listener?: AwarenessChangeHandler;
@@ -171,7 +163,6 @@ export class YRemoteSelectionsPluginValue implements PluginValue {
 	constructor(editor: EditorView) {
 		this.editor = editor;
 		this.decorations = RangeSet.of([]);
-		this.connectionManager = getConnectionManager(this.editor) ?? undefined;
 
 		// Allowlist: Check for live editing markers (same as LiveEditPlugin)
 		const sourceView = this.editor.dom.closest(".markdown-source-view");
@@ -187,9 +178,10 @@ export class YRemoteSelectionsPluginValue implements PluginValue {
 			return;
 		}
 
-		this.view = this.connectionManager?.findView(editor);
-		if (this.view && this.view instanceof LiveView) {
-			const provider = this.view.document?._provider;
+		const doc = this.resolveDocument();
+		if (doc) {
+			this.document = doc;
+			const provider = doc._provider;
 			this._listener = ({ added, updated, removed }, s, t) => {
 				const clients = added.concat(updated).concat(removed);
 				if (
@@ -207,24 +199,25 @@ export class YRemoteSelectionsPluginValue implements PluginValue {
 		}
 	}
 
-	getDocument(): Document | undefined {
-		const fileInfo = this.editor.state.field(editorInfoField);
-		const file = fileInfo.file;
-		
-		if (file) {
-			if (this.document?._tfile === file) {
-				return this.document;
-			}
-			const folder = this.connectionManager?.sharedFolders.lookup(file.path);
-			if (folder) {
-				this.document = folder.proxy.getDoc(file.path);
-				return this.document;
-			}
+	private resolveDocument(): Document | undefined {
+		const file = getEditorFile(this.editor);
+		if (!file) return undefined;
+
+		if (this.document?._tfile === file) {
+			return this.document;
 		}
-		
-		// Fallback to using view
-		this.view = this.connectionManager?.findView(this.editor);
-		return this.view?.document;
+
+		const sharedFolders = getSharedFolders(this.editor);
+		if (!sharedFolders) return undefined;
+
+		const folder = sharedFolders.lookup(file.path);
+		if (!folder) return undefined;
+
+		return folder.proxy.getDoc(file.path);
+	}
+
+	getDocument(): Document | undefined {
+		return this.resolveDocument();
 	}
 
 	destroy() {
@@ -233,8 +226,7 @@ export class YRemoteSelectionsPluginValue implements PluginValue {
 			this._awareness?.off("change", this._listener);
 			this._listener = undefined;
 		}
-		this.connectionManager = null as any;
-		this.view = null as any;
+		this.document = undefined;
 		this.editor = null as any;
 	}
 

--- a/styles.css
+++ b/styles.css
@@ -209,48 +209,24 @@
 	text-align: right;
 }
 
-@media (prefers-color-scheme: light) {
-	.file-diff__top-line__bg {
-		background-color: #d9f4ef;
-		border-radius: 0.25rem; /* 4px */
-	}
-
-	.file-diff_top-line__character {
-		background-color: #99e1d3;
-		border-radius: 0.25rem; /* 4px */
-	}
-
-	.file-diff__bottom-line__bg {
-		background-color: #d9edff;
-		border-radius: 0.25rem; /* 4px */
-	}
-
-	.file-diff_bottom-line__character {
-		background-color: #b1d4f2;
-		border-radius: 0.25rem; /* 4px */
-	}
+.file-diff__top-line__bg {
+	background-color: color-mix(in srgb, var(--color-green) 15%, transparent);
+	border-radius: 0.25rem; /* 4px */
 }
 
-@media (prefers-color-scheme: dark) {
-	.file-diff__top-line__bg {
-		background-color: #25403b;
-		border-radius: 0.25rem; /* 4px */
-	}
+.file-diff_top-line__character {
+	background-color: color-mix(in srgb, var(--color-green) 30%, transparent);
+	border-radius: 0.25rem; /* 4px */
+}
 
-	.file-diff_top-line__character {
-		background-color: #236559;
-		border-radius: 0.25rem; /* 4px */
-	}
+.file-diff__bottom-line__bg {
+	background-color: color-mix(in srgb, var(--interactive-accent) 12%, transparent);
+	border-radius: 0.25rem; /* 4px */
+}
 
-	.file-diff__bottom-line__bg {
-		background-color: #25394b;
-		border-radius: 0.25rem; /* 4px */
-	}
-
-	.file-diff_bottom-line__character {
-		background-color: #2e618d;
-		border-radius: 0.25rem; /* 4px */
-	}
+.file-diff_bottom-line__character {
+	background-color: color-mix(in srgb, var(--interactive-accent) 25%, transparent);
+	border-radius: 0.25rem; /* 4px */
 }
 
 .file-diff__no-bottom-border {


### PR DESCRIPTION
## Summary
- restore the missing `src/editorContext.ts` helper surface introduced by the editor-plugin refactor
- unblock `merge-hsm` staging builds by giving ShareLink, InvalidLink, LiveNode, RemoteSelections, and HSMEditorPlugin the current plugin/editor lookup helpers they import
- keep the fix narrowly scoped to the missing module so the live shard workflow can reach real tests again

## Validation
- `node esbuild.config.mjs staging`
- `npm test -- --runInBand`
- targeted workflow dispatch from this branch against `origin/fix/editor-context-merge-hsm` (`tests=test-basic-open-close`)
