### PR TITLE
fix: restore editor context module on live merge-hsm

### DIFF
--- a/.github/workflows/e2e-standard.yml
+++ b/.github/workflows/e2e-standard.yml
@@ -14,16 +14,53 @@ on:
         required: false
         default: ''
 
+concurrency:
+  group: e2e-standard-linux
+  cancel-in-progress: false
+
 env:
-  VM_NAME: ${{ secrets.GCP_VM_NAME }}
   VM_ZONE: ${{ secrets.GCP_VM_ZONE }}
   GCP_PROJECT: ${{ secrets.GCP_PROJECT }}
   GCP_USE_IAP: "true"
 
 jobs:
   standard-test:
+    name: ${{ format('standard-test ({0})', matrix.shard.name) }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      max-parallel: 7
+      matrix:
+        shard:
+          - name: foundation-core
+            slug: foundation-core
+            tests: test-basic-open-close,test-folder-lifecycle,test-view-reuse-file-switching
+          - name: foundation-share
+            slug: foundation-share
+            tests: test-share-folder,test-in-note-status
+          - name: sync-state
+            slug: sync-state
+            tests: test-idle-registration,test-active-editor-sync,test-offline-banner,test-binary-free-user
+          - name: conflicts-differ
+            slug: conflicts-differ
+            tests: test-differ-resolve,test-trigger-differ,test-differ-dismissal
+          - name: conflicts-resolution
+            slug: conflicts-resolution
+            tests: test-conflict-dismiss,test-conflict-cancel,test-upgrade-no-lca-conflict
+          - name: bulk-upload
+            slug: bulk
+            tests: test-bulk-upload
+          - name: restart-heavy
+            slug: restart
+            tests: test-bases-checkbox-sync,test-obsidian-restart,test-cold-reopen-external-edit
+    env:
+      VM_NAME: ${{ format('{0}-{1}', secrets.GCP_VM_NAME, matrix.shard.slug) }}
+      SHARD_NAME: ${{ matrix.shard.name }}
+      SHARD_SLUG: ${{ matrix.shard.slug }}
+      SHARD_TESTS: ${{ matrix.shard.tests }}
+      GCP_VM_DISK_SIZE: 20GB
+      GCP_VM_DISK_TYPE: pd-standard
 
     steps:
       - name: Auth to GCP
@@ -34,7 +71,52 @@ jobs:
       - name: Setup gcloud
         uses: google-github-actions/setup-gcloud@v2
 
+      - name: Select tests for shard
+        id: select-tests
+        run: |
+          TARGETED_TESTS="${{ github.event.inputs.tests || '' }}"
+          SHARD_TESTS="${{ matrix.shard.tests }}"
+
+          select_tests() {
+            local available="$1"
+            local wanted="$2"
+            local filtered=""
+            local test match
+
+            IFS=',' read -r -a available_tests <<< "$available"
+            IFS=',' read -r -a wanted_tests <<< "$wanted"
+
+            for test in "${available_tests[@]}"; do
+              test="${test//[[:space:]]/}"
+              [ -n "$test" ] || continue
+              for match in "${wanted_tests[@]}"; do
+                match="${match//[[:space:]]/}"
+                [ -n "$match" ] || continue
+                if [ "$test" = "$match" ]; then
+                  filtered="${filtered:+$filtered,}$test"
+                  break
+                fi
+              done
+            done
+
+            printf '%s' "$filtered"
+          }
+
+          SELECTED_TESTS="$SHARD_TESTS"
+          if [ -n "$TARGETED_TESTS" ]; then
+            SELECTED_TESTS="$(select_tests "$SHARD_TESTS" "$TARGETED_TESTS")"
+          fi
+
+          if [ -n "$SELECTED_TESTS" ]; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            echo "selected_tests=$SELECTED_TESTS" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            echo "selected_tests=" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Clone relay-harness
+        if: steps.select-tests.outputs.should_run == 'true'
         run: |
           mkdir -p ~/.ssh
           echo '${{ secrets.HARNESS_DEPLOY_KEY }}' > ~/.ssh/harness-key
@@ -56,6 +138,7 @@ jobs:
           git clone git@github.com:No-Instructions/relay-harness.git ~/relay-harness
 
       - name: Ensure VM is running
+        if: steps.select-tests.outputs.should_run == 'true'
         run: |
           STATUS=$(gcloud compute instances describe "$VM_NAME" \
             --zone="$VM_ZONE" --project="$GCP_PROJECT" \
@@ -64,7 +147,9 @@ jobs:
           if [ "$STATUS" = "NOT_FOUND" ]; then
             echo "VM does not exist. Creating via harness infra scripts..."
             cd ~/relay-harness
-            GCP_PROJECT="$GCP_PROJECT" GCP_ZONE="$VM_ZONE" ./infra/gcp-linux-vm.sh create
+            GCP_PROJECT="$GCP_PROJECT" GCP_ZONE="$VM_ZONE" GCP_VM_NAME="$VM_NAME" \
+              GCP_VM_DISK_SIZE="$GCP_VM_DISK_SIZE" GCP_VM_DISK_TYPE="$GCP_VM_DISK_TYPE" \
+              ./infra/gcp-linux-vm.sh create
           elif [ "$STATUS" = "TERMINATED" ] || [ "$STATUS" = "STOPPED" ]; then
             echo "Starting stopped VM..."
             gcloud compute instances start "$VM_NAME" \
@@ -98,55 +183,87 @@ jobs:
           done
 
       - name: Provision VM credentials
+        if: steps.select-tests.outputs.should_run == 'true'
         run: |
+          scp_retry() {
+            local src="$1"
+            local dest="$2"
+            local label="$3"
+            local attempt
+
+            for attempt in $(seq 1 5); do
+              if gcloud compute scp --quiet "$src" "$VM_NAME":"$dest" \
+                --zone="$VM_ZONE" --project="$GCP_PROJECT" \
+                --tunnel-through-iap; then
+                return 0
+              fi
+              echo "Retrying $label scp ($attempt/5) ..."
+              sleep 5
+            done
+
+            echo "Failed to copy $label to VM after 5 attempts"
+            return 1
+          }
+
+          ssh_retry() {
+            local label="$1"
+            local command="$2"
+            local attempt
+
+            for attempt in $(seq 1 5); do
+              if gcloud compute ssh "$VM_NAME" --quiet \
+                --zone="$VM_ZONE" --project="$GCP_PROJECT" \
+                --tunnel-through-iap \
+                --command="$command"; then
+                return 0
+              fi
+              echo "Retrying $label ssh command ($attempt/5) ..."
+              sleep 5
+            done
+
+            echo "Failed $label ssh command after 5 attempts"
+            return 1
+          }
+
           echo '${{ secrets.GCP_SA_KEY }}' > /tmp/sa-key.json
-          gcloud compute scp --quiet /tmp/sa-key.json "$VM_NAME":~/ci-sa-key.json \
-            --zone="$VM_ZONE" --project="$GCP_PROJECT" \
-            --tunnel-through-iap 2>/dev/null
+          scp_retry /tmp/sa-key.json ~/ci-sa-key.json "service-account key"
           rm -f /tmp/sa-key.json
 
           echo '${{ secrets.HARNESS_DEPLOY_KEY }}' > /tmp/deploy-key
           chmod 600 /tmp/deploy-key
-          gcloud compute scp --quiet /tmp/deploy-key "$VM_NAME":~/ci-deploy-key \
-            --zone="$VM_ZONE" --project="$GCP_PROJECT" \
-            --tunnel-through-iap 2>/dev/null
+          scp_retry /tmp/deploy-key ~/ci-deploy-key "deploy key"
           rm -f /tmp/deploy-key
 
           # GitHub App private key for posting Check Runs
           echo '${{ secrets.E2E_APP_KEY }}' > /tmp/github-app-key.pem
           chmod 600 /tmp/github-app-key.pem
-          gcloud compute ssh "$VM_NAME" --quiet \
-            --zone="$VM_ZONE" --project="$GCP_PROJECT" \
-            --tunnel-through-iap \
-            --command="mkdir -p ~/.config/relay-e2e" 2>/dev/null
-          gcloud compute scp --quiet /tmp/github-app-key.pem "$VM_NAME":~/.config/relay-e2e/github-app-key.pem \
-            --zone="$VM_ZONE" --project="$GCP_PROJECT" \
-            --tunnel-through-iap 2>/dev/null
+          ssh_retry "relay-e2e config dir creation" "mkdir -p ~/.config/relay-e2e"
+          scp_retry /tmp/github-app-key.pem ~/.config/relay-e2e/github-app-key.pem "GitHub App key"
           rm -f /tmp/github-app-key.pem
 
           # R2 credentials for ci.system3.dev uploads
-          gcloud compute ssh "$VM_NAME" --quiet \
-            --zone="$VM_ZONE" --project="$GCP_PROJECT" \
-            --tunnel-through-iap \
-            --command="cat > ~/.config/relay-e2e/r2-env.sh << 'CREDS'
+          ssh_retry "R2 env write" "cat > ~/.config/relay-e2e/r2-env.sh << 'CREDS'
           export CI_R2_ENDPOINT='${{ secrets.CI_R2_ENDPOINT }}'
           export CI_R2_ACCESS_KEY_ID='${{ secrets.CI_R2_ACCESS_KEY_ID }}'
           export CI_R2_SECRET_ACCESS_KEY='${{ secrets.CI_R2_SECRET_ACCESS_KEY }}'
           CREDS
-          chmod 600 ~/.config/relay-e2e/r2-env.sh" 2>/dev/null
+          chmod 600 ~/.config/relay-e2e/r2-env.sh"
 
       - name: Run standard suite on VM
+        if: steps.select-tests.outputs.should_run == 'true'
         run: |
           REF="${{ github.event.inputs.ref || format('origin/{0}', github.ref_name) }}"
-          TARGETED_TESTS="${{ github.event.inputs.tests || '' }}"
+          SELECTED_TESTS="${{ steps.select-tests.outputs.selected_tests }}"
+          SHARD_SLUG_ARG="${{ matrix.shard.slug }}"
 
           gcloud compute ssh "$VM_NAME" --quiet \
             --zone="$VM_ZONE" --project="$GCP_PROJECT" \
             --tunnel-through-iap \
-            --command="bash -s -- '$REF' '$TARGETED_TESTS'" 2>/dev/null << 'REMOTE_SCRIPT'
+            --command="bash -s -- '$REF' '$SELECTED_TESTS' '$SHARD_SLUG_ARG'" 2>/dev/null << 'REMOTE_SCRIPT'
           set -eo pipefail
           REF="$1"
-          TARGETED_TESTS="$2"
+          SELECTED_TESTS="$2"
+          SHARD_SLUG="$3"
 
           # Load R2 credentials
           [ -f ~/.config/relay-e2e/r2-env.sh ] && source ~/.config/relay-e2e/r2-env.sh
@@ -219,16 +336,17 @@ jobs:
           cd ~/relay-harness
 
           TEST_EXIT=0
-          TEST_CMD=(./scripts/run-e2e-suite.sh "$REF" --upload --checks)
-          if [ -n "$TARGETED_TESTS" ]; then
-            TEST_CMD+=("--tests=$TARGETED_TESTS")
-          fi
-          "${TEST_CMD[@]}" || TEST_EXIT=$?
+          TEST_CMD=(./scripts/run-e2e-suite.sh "$REF" --upload)
+          TEST_CMD+=("--tests=$SELECTED_TESTS")
+          RELAY_RUN_EXEC_SUFFIX="$SHARD_SLUG" "${TEST_CMD[@]}" || TEST_EXIT=$?
 
           # Extract results for the GitHub Actions runner
-          LATEST=$(ls -td /tmp/test-reports/runs/*/* 2>/dev/null | head -1)
-          if [ -n "$LATEST" ] && [ -f "$LATEST/summary.json" ]; then
-            cp "$LATEST/summary.json" ~/test-summary.json
+          LATEST_SUMMARY=$(find /tmp/test-reports/runs -mindepth 3 -maxdepth 3 -type f -name summary.json -print0 2>/dev/null \
+            | xargs -0 ls -t 2>/dev/null \
+            | head -1)
+          if [ -n "$LATEST_SUMMARY" ]; then
+            LATEST="$(dirname "$LATEST_SUMMARY")"
+            cp "$LATEST_SUMMARY" ~/test-summary.json
 
             COMMIT=$(basename "$(dirname "$LATEST")")
             EXEC_ID=$(basename "$LATEST")
@@ -246,7 +364,7 @@ jobs:
           REMOTE_SCRIPT
 
       - name: Clean up VM credentials
-        if: always()
+        if: always() && steps.select-tests.outputs.should_run == 'true'
         run: |
           gcloud compute ssh "$VM_NAME" --quiet \
             --zone="$VM_ZONE" --project="$GCP_PROJECT" \
@@ -254,7 +372,7 @@ jobs:
             --command="rm -f ~/ci-sa-key.json ~/ci-deploy-key ~/.ssh/ci-deploy-key ~/.config/relay-e2e/github-app-key.pem ~/.config/relay-e2e/r2-env.sh" 2>/dev/null || true
 
       - name: Fetch results
-        if: always()
+        if: always() && steps.select-tests.outputs.should_run == 'true'
         run: |
           gcloud compute scp --quiet "$VM_NAME":~/test-summary.json ./summary.json \
             --zone="$VM_ZONE" --project="$GCP_PROJECT" \
@@ -263,18 +381,42 @@ jobs:
             --zone="$VM_ZONE" --project="$GCP_PROJECT" \
             --tunnel-through-iap 2>/dev/null || true
 
+      - name: Request shard VM stop
+        if: always() && steps.select-tests.outputs.should_run == 'true'
+        run: |
+          STATUS=$(gcloud compute instances describe "$VM_NAME" \
+            --zone="$VM_ZONE" --project="$GCP_PROJECT" \
+            --format='get(status)' 2>/dev/null || echo "NOT_FOUND")
+
+          if [ "$STATUS" = "RUNNING" ]; then
+            echo "Requesting asynchronous stop for shard VM..."
+            gcloud compute instances stop "$VM_NAME" \
+              --zone="$VM_ZONE" --project="$GCP_PROJECT" \
+              --quiet --async 2>/dev/null || true
+          else
+            echo "Skipping stop request (status: $STATUS)"
+          fi
+
       - name: Generate job summary
         if: always()
         uses: actions/github-script@v7
         with:
           script: |
             const fs = require('fs');
+            const shardName = process.env.SHARD_NAME || 'shard';
+            const shouldRun = process.env.RUN_SHARD === 'true';
+
+            if (!shouldRun) {
+              core.summary.addRaw(`## E2E standard suite results (${shardName})\n\n:warning: **SKIPPED** | no matching tests for this shard\n`);
+              await core.summary.write();
+              return;
+            }
 
             let summary, metadata;
             try {
               summary = JSON.parse(fs.readFileSync('summary.json', 'utf-8'));
             } catch {
-              core.summary.addRaw('## E2E standard suite results\n\n:x: **Failed to retrieve test results from VM**\n');
+              core.summary.addRaw(`## E2E standard suite results (${shardName})\n\n:x: **Failed to retrieve test results from VM**\n`);
               await core.summary.write();
               core.setFailed('No test results available');
               return;
@@ -307,7 +449,7 @@ jobs:
             if (s.expectedFail) parts.push(`${s.expectedFail} expected-fail`);
             if (s.unexpectedPass) parts.push(`${s.unexpectedPass} unexpected-pass`);
 
-            let md = `## E2E standard suite results\n\n`;
+            let md = `## E2E standard suite results (${shardName})\n\n`;
             md += `${verdictEmoji} **${verdictText}** | ${parts.join(', ')} | ${totalDur}s`;
             if (metadata.reportUrl) {
               md += ` | [Full Report](${metadata.reportUrl})`;
@@ -343,3 +485,5 @@ jobs:
             } else if ((s.fail || 0) > 0) {
               core.setFailed(`${s.fail} test(s) failed`);
             }
+        env:
+          RUN_SHARD: ${{ steps.select-tests.outputs.should_run }}

--- a/src/AwarenessViewPlugin.ts
+++ b/src/AwarenessViewPlugin.ts
@@ -3,6 +3,7 @@ import { MarkdownView } from "obsidian";
 import { Document } from "./Document";
 import { type LiveView } from "./LiveViews";
 import UserAwareness from "./components/UserAwareness.svelte";
+import { trackPromise } from "./trackPromise";
 export class AwarenessViewPlugin extends HasLogging {
 	view: LiveView<MarkdownView>;
 	doc: Document;
@@ -30,7 +31,7 @@ export class AwarenessViewPlugin extends HasLogging {
 		this.wrapTitle();
 
 		// Wait for the document to be ready
-		await this.doc.whenReady();
+		await trackPromise(`awareness:whenReady:${this.doc.guid}`, this.doc.whenReady());
 
 		if (this.destroyed) return;
 

--- a/src/BackgroundSync.ts
+++ b/src/BackgroundSync.ts
@@ -16,6 +16,7 @@ import { Canvas } from "./Canvas";
 import { areObjectsEqual } from "./areObjectsEqual";
 import type { CanvasData } from "./CanvasView";
 import { SyncFile, isSyncFile } from "./SyncFile";
+import { isEmptyDoc } from "./merge-hsm/state-vectors";
 
 export interface QueueItem {
 	guid: string;
@@ -865,12 +866,9 @@ export class BackgroundSync extends HasLogging {
 		const updateBytes = new Uint8Array(response.arrayBuffer);
 
 		// Peek at the update in a throwaway doc to detect empty-server.
-		// Same detection as getDocument(): empty contents AND empty users.
 		const tmpDoc = new Y.Doc();
 		Y.applyUpdate(tmpDoc, updateBytes);
-		const users = tmpDoc.getMap("users");
-		const contents = tmpDoc.getText("contents").toString();
-		if (contents === "" && users.size === 0) {
+		if (isEmptyDoc(tmpDoc)) {
 			this.log(
 				"[downloadByGuid] server has guid registered but no content",
 				path,
@@ -911,10 +909,25 @@ export class BackgroundSync extends HasLogging {
 		}
 		const intent = doc.intent;
 		if (doc.destroyed) return false;
-		const providerSynced = doc.onceProviderSynced().then(() => true);
 		doc.connect();
-		if (intent === "disconnected") {
-			await providerSynced;
+		// Always wait for provider sync — _providerSynced fast-path resolves
+		// immediately if already synced.  Connected does not imply synced.
+		// Timeout prevents hanging the sync queue if the connection drops.
+		const SYNC_TIMEOUT_MS = 10_000;
+		let timerId: number | undefined;
+		const synced = await Promise.race([
+			doc.onceProviderSynced().then(() => true),
+			new Promise<false>((resolve) => {
+				timerId = this.timeProvider.setTimeout(
+					() => resolve(false),
+					SYNC_TIMEOUT_MS,
+				);
+			}),
+		]);
+		if (timerId !== undefined) this.timeProvider.clearTimeout(timerId);
+		if (!synced) {
+			this.warn(`[syncDocWS] provider sync timed out: ${doc.path} guid=${doc.guid}`);
+			return false;
 		}
 
 		// promise can take some time
@@ -984,34 +997,29 @@ export class BackgroundSync extends HasLogging {
 			const rawUpdate = response.arrayBuffer;
 			const updateBytes = new Uint8Array(rawUpdate);
 
-			// Validate: reject uninitialized documents
+			// Validate: reject uninitialized documents.
 			const newDoc = new Y.Doc();
 			Y.applyUpdate(newDoc, updateBytes);
-			const users = newDoc.getMap("users");
-			const contents = newDoc.getText("contents").toString();
 
-			if (contents === "") {
-				if (users.size === 0) {
-					this.log(
-						"[getDocument] Server contains uninitialized document. Waiting for peer to upload.",
-						users.size,
-						retry,
-						wait,
-					);
-					if (retry > 0) {
-						this.timeProvider.setTimeout(() => {
-							this.getDocument(doc, retry - 1, wait * 2);
-						}, wait);
-					}
-					return undefined;
-				}
+			if (isEmptyDoc(newDoc)) {
 				if (doc.text) {
 					this.log(
-						"[getDocument] local crdt has contents, but remote is empty",
+						"[getDocument] server CRDT empty, local has content — uploading",
 					);
 					this.enqueueSync(doc);
 					return undefined;
 				}
+				this.log(
+					"[getDocument] Server contains uninitialized document. Waiting for peer to upload.",
+					retry,
+					wait,
+				);
+				if (retry > 0) {
+					this.timeProvider.setTimeout(() => {
+						this.getDocument(doc, retry - 1, wait * 2);
+					}, wait);
+				}
+				return undefined;
 			}
 
 			this.log("[getDocument] applying content from server");

--- a/src/Canvas.ts
+++ b/src/Canvas.ts
@@ -17,6 +17,7 @@ import type {
 	CanvasView,
 } from "./CanvasView";
 import { areObjectsEqual } from "./areObjectsEqual";
+import { trackPromise } from "./trackPromise";
 
 export function isCanvas(file?: IFile | null): file is Canvas {
 	return file instanceof Canvas;
@@ -99,7 +100,7 @@ export class Canvas extends HasProvider implements IFile, HasMimeType {
 			(async () => {
 				const serverSynced = await this.getServerSynced();
 				if (!serverSynced) {
-					await this.onceProviderSynced();
+					await trackPromise(`canvasSync:${this.guid}`, this.onceProviderSynced());
 					await this.markSynced();
 				}
 			})();
@@ -198,9 +199,9 @@ export class Canvas extends HasProvider implements IFile, HasMimeType {
 				// If this is a brand new shared folder, we want to wait for a connection before we start reserving new guids for local files.
 				this.log("awaiting updates");
 				this.connect();
-				await this.onceConnected();
+				await trackPromise(`canvasConnected:${this.guid}`, this.onceConnected());
 				this.log("connected");
-				await this.onceProviderSynced();
+				await trackPromise(`canvasReady:${this.guid}`, this.onceProviderSynced());
 				this.log("synced");
 				return this;
 			}
@@ -211,7 +212,7 @@ export class Canvas extends HasProvider implements IFile, HasMimeType {
 			new Dependency<Canvas>(promiseFn, (): [boolean, Canvas] => {
 				return [this.ready, this];
 			});
-		return this.readyPromise.getPromise();
+		return trackPromise(`canvas:whenReady:${this.guid}`, this.readyPromise.getPromise());
 	}
 
 	whenSynced(): Promise<void> {
@@ -239,13 +240,13 @@ export class Canvas extends HasProvider implements IFile, HasMimeType {
 			new Dependency<void>(promiseFn, (): [boolean, void] => {
 				return [this.persistenceSynced, undefined];
 			});
-		return this.whenSyncedPromise.getPromise();
+		return trackPromise(`canvas:whenSynced:${this.guid}`, this.whenSyncedPromise.getPromise());
 	}
 
 	/**
 	 * Release lock on this canvas.
 	 * Transitions HSM from active back to idle mode.
-	 * Call this when editor closes (replaces userLock = false).
+	 * Call this when editor closes.
 	 */
 	releaseLock(): void {
 		this.userLock = false;

--- a/src/CanvasPlugin.ts
+++ b/src/CanvasPlugin.ts
@@ -14,6 +14,7 @@ import { HasLogging } from "src/debug";
 import * as Y from "yjs";
 import { ViewHookPlugin } from "./plugins/ViewHookPlugin";
 import { flags } from "./flagManager";
+import type { EditorViewRef } from "./merge-hsm/types";
 
 export class CanvasPlugin extends HasLogging {
 	view: CanvasView;
@@ -134,17 +135,32 @@ export class CanvasPlugin extends HasLogging {
 				// Read editor content: the embed's CM6 editor may start empty,
 				// so use the child view's data (which holds the disk content).
 				const editorContent = embedView.data ?? "";
-				document.acquireLock(editorContent).catch((error: unknown) => {
-					this.error(
-						"Error acquiring lock for canvas embed:",
-						error,
-					);
-				});
+				document
+					.whenReady()
+					.then(() => {
+						const viewRef = embedView as EditorViewRef;
+						const lockHolder = embedView.leaf ?? undefined;
+						return this.connectionManager.acquireDocumentLock(
+							document,
+							viewRef,
+							lockHolder,
+							editorContent,
+						);
+					})
+					.catch((error: unknown) => {
+						this.error(
+							"Error acquiring lock for canvas embed:",
+							error,
+						);
+					});
 
 				return () => {
 					this.trackedEmbedViews.delete(embedView);
 					plugin.destroy();
-					document.releaseLock();
+					this.connectionManager.releaseDocumentLock(
+						document,
+						embedView.leaf ?? undefined,
+					);
 				};
 			})(),
 		);

--- a/src/Document.ts
+++ b/src/Document.ts
@@ -15,10 +15,14 @@ import type { HasMimeType, IFile } from "./IFile";
 import { getMimeType } from "./mimetypes";
 import type { MergeHSM } from "./merge-hsm/MergeHSM";
 import type { EditorViewRef } from "./merge-hsm/types";
-import { ProviderIntegration, type YjsProvider } from "./merge-hsm/integration/ProviderIntegration";
+import {
+	ProviderIntegration,
+	type YjsProvider,
+} from "./merge-hsm/integration/ProviderIntegration";
 import { reconnectProvider } from "./merge-hsm/integration/ProviderLifecycle";
 import { generateHash } from "./hashing";
 import { awaitOnReload } from "./reloadUtils";
+import { trackPromise } from "./trackPromise";
 
 export function isDocument(file?: IFile): file is Document {
 	return file instanceof Document;
@@ -49,10 +53,9 @@ export class Document extends HasProvider implements IFile, HasMimeType {
 
 	/**
 	 * MergeHSM instance for this document.
-	 * Only available when HSM active mode is enabled.
-	 * Use acquireLock() to get/create the HSM.
+	 * Created in the constructor and cleared on destroy().
 	 */
-	private _hsm: MergeHSM | null = null;
+	private _hsm: MergeHSM | null;
 
 	/**
 	 * ProviderIntegration instance for bridging HSM with the provider.
@@ -91,8 +94,45 @@ export class Document extends HasProvider implements IFile, HasMimeType {
 		// Initialize HSM immediately so it's always available for filtering disk changes.
 		// The HSM starts in loading state and transitions to idle once persistence loads.
 		// Document owns the HSM - use ensureHSM() which uses MergeManager as a factory.
-		this.ensureHSM();
+		const mergeManager = this.sharedFolder?.mergeManager;
+		if (!mergeManager) {
+			throw new Error("no merge manager");
+		}
 
+		// Create HSM using factory
+		this._hsm = mergeManager.createHSM({
+			guid: this.guid,
+			getPath: () => this.path,
+			remoteDoc: this.isRemoteDocLoaded ? this.ydoc : null,
+			getDiskContent: () => this.readDiskContent(),
+			getPersistenceMetadata: () => ({
+				path: this.path,
+				relay: this.sharedFolder.relayId || "",
+				appId: this.sharedFolder.appId,
+				s3rn: this.s3rn ? S3RN.encode(this.s3rn) : "",
+			}),
+		});
+
+		// Subscribe to effects
+		this.unsubscribes.push(
+			this._hsm.subscribe((effect) => {
+				this.handleEffect(effect);
+			}),
+		);
+
+		// Subscribe to state changes for sync status updates
+		this.unsubscribes.push(
+			this._hsm.onStateChange(() => {
+				const syncStatus = this._hsm?.getSyncStatus();
+				if (!syncStatus) {
+					return;
+				}
+				mergeManager.updateSyncStatus(this.guid, syncStatus);
+			}),
+		);
+
+		// Notify MergeManager for hibernation tracking
+		mergeManager.notifyHSMCreated(this.guid);
 		this.unsubscribes.push(
 			this._parent.subscribe(this.path, (state) => {
 				if (state.intent === "disconnected") {
@@ -187,55 +227,6 @@ export class Document extends HasProvider implements IFile, HasMimeType {
 	}
 
 	/**
-	 * Ensure an HSM exists for this document, creating one if needed.
-	 * Document owns the HSM - MergeManager is just a factory.
-	 * @returns The MergeHSM instance, or null if MergeManager not available
-	 */
-	ensureHSM(): MergeHSM | null {
-		if (this._hsm) {
-			return this._hsm;
-		}
-
-		const mergeManager = this.sharedFolder?.mergeManager;
-		if (!mergeManager) {
-			return null;
-		}
-
-		// Create HSM using factory
-		this._hsm = mergeManager.createHSM({
-			guid: this.guid,
-			getPath: () => this.path,
-			remoteDoc: this.isRemoteDocLoaded ? this.ydoc : null,
-			getDiskContent: () => this.readDiskContent(),
-			getPersistenceMetadata: () => ({
-				path: this.path,
-				relay: this.sharedFolder.relayId || "",
-				appId: this.sharedFolder.appId,
-				s3rn: this.s3rn ? S3RN.encode(this.s3rn) : "",
-			}),
-		});
-
-		// Subscribe to effects
-		this.unsubscribes.push(
-			this._hsm.subscribe((effect) => {
-				this.handleEffect(effect);
-			}),
-		);
-
-		// Subscribe to state changes for sync status updates
-		this.unsubscribes.push(
-			this._hsm.onStateChange(() => {
-				mergeManager.updateSyncStatus(this.guid, this._hsm!.getSyncStatus());
-			}),
-		);
-
-		// Notify MergeManager for hibernation tracking
-		mergeManager.notifyHSMCreated(this.guid);
-
-		return this._hsm;
-	}
-
-	/**
 	 * Create the remote YDoc, populating it from localDoc if available.
 	 * This ensures the remoteDoc has content for provider sync even when
 	 * content was enrolled into localDoc (e.g., via initializeWithContent).
@@ -243,13 +234,17 @@ export class Document extends HasProvider implements IFile, HasMimeType {
 	ensureRemoteDoc(): Y.Doc {
 		const isNew = !this.isRemoteDocLoaded;
 		const doc = super.ensureRemoteDoc();
-		if (isNew && this._hsm) {
+		const hsm = this._hsm;
+		if (!hsm) {
+			return doc;
+		}
+		if (isNew) {
 			// Seed remoteDoc from localDoc so the provider can sync local
 			// state to the server. Skip when a fork exists — the fork gates
 			// local→remote sync because the two sides are intentionally
 			// diverged until conflict resolution completes.
-			const localDoc = this._hsm.getLocalDoc();
-			if (localDoc && !this._hsm.hasFork()) {
+			const localDoc = hsm.getLocalDoc();
+			if (localDoc && !hsm.hasFork()) {
 				const update = Y.encodeStateAsUpdate(localDoc);
 				// Use the provider as origin so _updateHandler skips this —
 				// it's rehydration from local state, not a new edit.
@@ -262,92 +257,73 @@ export class Document extends HasProvider implements IFile, HasMimeType {
 	/**
 	 * Acquire lock on this document for active editing.
 	 * Transitions HSM from idle to active mode.
-	 * Call this when editor opens (replaces userLock = true).
+	 * Call this when editor opens.
 	 *
-	 * @param editorContent - The current editor/disk content (required in v6).
-	 *   Since the editor content equals the disk content when a file is first
-	 *   opened (before CRDT loads), this provides accurate disk content for
-	 *   merge operations. Pass the content from the editor or read from disk.
-	 * @returns The MergeHSM instance, or null if HSM is not enabled
+	 * @param editorContent - The current editor/disk content. Since the editor
+	 *   content equals the disk content when a file is first opened (before
+	 *   CRDT loads), this provides accurate disk content for merge operations.
+	 *   Pass the content from the editor or read from disk.
+	 * @returns The MergeHSM instance
 	 */
-	async acquireLock(editorContent?: string, editorViewRef?: EditorViewRef): Promise<MergeHSM | null> {
+	acquireLock(editorContent: string, editorViewRef: EditorViewRef): MergeHSM {
 		const mergeManager = this.sharedFolder.mergeManager;
-		if (!mergeManager || !this._hsm) {
-			this.userLock = true; // Fallback if MergeManager/HSM not available
-			return null;
+		if (!mergeManager) {
+			throw new Error("no merge manager");
+		}
+		const hsm = this._hsm;
+		if (!hsm) {
+			throw new Error("no hsm");
 		}
 
-		try {
-			// v6: If editorContent not provided, read from disk (fallback for backward compatibility)
-			let content = editorContent;
-			if (content === undefined) {
-				const tfile = this.tfile;
-				if (tfile) {
-					content = await this.vault.read(tfile);
-				} else {
-					content = "";  // New file, no content yet
-				}
-			}
-
-			// Ensure remoteDoc and provider exist before entering active mode.
-			// This wakes the document from hibernation if needed.
-			const remoteDoc = this.ensureRemoteDoc();
-			this._hsm.setRemoteDoc(remoteDoc);
-
-			// Send ACQUIRE_LOCK with editorContent to transition from idle to active.
-			// Always send (don't guard with isLoaded) because releaseLock() doesn't await
-			// unload(), so activeDocs may not be cleared when file is quickly reopened.
-			// The HSM handles duplicate ACQUIRE_LOCK gracefully (no-op if already active).
-			this._hsm.send({ type: "ACQUIRE_LOCK", editorContent: content, editorViewRef });
-			mergeManager.markActive(this.guid);
-
-			// Create ProviderIntegration BEFORE awaiting so it can deliver
-			// PROVIDER_SYNCED during the entering phase (needed for empty-IDB flow).
-			if (!this._providerIntegration) {
-				this._providerIntegration = new ProviderIntegration(
-					this._hsm,
-					remoteDoc,
-					this._provider! as YjsProvider
-				);
-			}
-
-			// Ensure provider is connected. After idle-mode fork
-			// reconciliation, destroyIdleProviderIntegration disconnects
-			// the provider. Without reconnecting, SYNC_TO_REMOTE updates
-			// from conflict resolution are buffered but never sent.
-			// connect() is a no-op if already connected.
+		// Idempotent fast path: if this document is already active and has an
+		// integration bridge, keep that lock and simply ensure connectivity.
+		if (mergeManager.isActive(this.guid) && this._providerIntegration) {
 			this.connect();
-
-			// Wait for HSM to reach a post-entering active state
-			await this._hsm.awaitActive();
-
-			// Guard against race: releaseLock() may have been called while we
-			// were awaiting. If so, the HSM has already transitioned back to idle
-			// and we must not keep a ProviderIntegration (it would leak).
-			if (!this.userLock && !mergeManager.isActive(this.guid)) {
-				this._providerIntegration.destroy();
-				this._providerIntegration = null;
-				return null;
-			}
-
-			this.userLock = true; // Keep for compatibility
-
-			return this._hsm;
-		} catch (e) {
-			this.warn("[acquireLock] Failed to acquire HSM lock:", e);
-			this.userLock = true; // Fallback
-			return null;
+			return hsm;
 		}
+
+		// Ensure remoteDoc and provider exist before entering active mode.
+		// This wakes the document from hibernation if needed.
+		const remoteDoc = this.ensureRemoteDoc();
+		hsm.setRemoteDoc(remoteDoc);
+
+		// Send ACQUIRE_LOCK with editorContent to transition from idle to active.
+		// Always send (don't guard with isLoaded) because releaseLock() doesn't await
+		// unload(), so activeDocs may not be cleared when file is quickly reopened.
+		// The HSM handles duplicate ACQUIRE_LOCK gracefully (no-op if already active).
+		hsm.send({
+			type: "ACQUIRE_LOCK",
+			editorContent: editorContent,
+			editorViewRef,
+		});
+		mergeManager.markActive(this.guid);
+
+		// Create ProviderIntegration BEFORE awaiting so it can deliver
+		// PROVIDER_SYNCED during the entering phase (needed for empty-IDB flow).
+		if (!this._providerIntegration) {
+			this._providerIntegration = new ProviderIntegration(
+				hsm,
+				remoteDoc,
+				this._provider! as YjsProvider,
+			);
+		}
+
+		// Ensure provider is connected. After idle-mode fork
+		// reconciliation, destroyIdleProviderIntegration disconnects
+		// the provider. Without reconnecting, SYNC_TO_REMOTE updates
+		// from conflict resolution are buffered but never sent.
+		// connect() is a no-op if already connected.
+		this.connect();
+
+		return hsm;
 	}
 
 	/**
 	 * Release lock on this document.
 	 * Transitions HSM from active back to idle mode.
-	 * Call this when editor closes (replaces userLock = false).
+	 * Call this when editor closes.
 	 */
 	releaseLock(): void {
-		this.userLock = false; // Keep for compatibility
-
 		// Destroy ProviderIntegration (unsubscribes from events)
 		if (this._providerIntegration) {
 			this._providerIntegration.destroy();
@@ -434,7 +410,7 @@ export class Document extends HasProvider implements IFile, HasMimeType {
 		const doc = this.localDoc;
 		if (!doc) {
 			throw new Error(
-				`Document ${this.path}: Cannot access localYText - HSM not in active mode.`
+				`Document ${this.path}: Cannot access localYText - HSM not in active mode.`,
 			);
 		}
 		return doc.getText("contents");
@@ -462,7 +438,7 @@ export class Document extends HasProvider implements IFile, HasMimeType {
 		if (!localDoc) {
 			throw new Error(
 				`Document ${this.path}: Cannot write - HSM not in active mode. ` +
-				`Writing to ydoc (remoteDoc) directly causes corruption.`
+					`Writing to ydoc (remoteDoc) directly causes corruption.`,
 			);
 		}
 		return localDoc;
@@ -531,9 +507,12 @@ export class Document extends HasProvider implements IFile, HasMimeType {
 				// If this is a brand new shared folder, we want to wait for a connection before we start reserving new guids for local files.
 				this.log("awaiting updates");
 				this.connect();
-				await this.onceConnected();
+				await trackPromise(`connected:${this.guid}`, this.onceConnected());
 				this.log("connected");
-				await this.onceProviderSynced();
+				await trackPromise(
+					`providerSync:${this.guid}`,
+					this.onceProviderSynced(),
+				);
 				this.log("synced");
 				this._awaitingUpdates = false;
 			}
@@ -544,7 +523,10 @@ export class Document extends HasProvider implements IFile, HasMimeType {
 			new Dependency<Document>(promiseFn, (): [boolean, Document] => {
 				return [this.ready, this];
 			});
-		return this.readyPromise.getPromise();
+		return trackPromise(
+			`doc:whenReady:${this.guid}`,
+			this.readyPromise.getPromise(),
+		);
 	}
 
 	whenSynced(): Promise<void> {
@@ -559,7 +541,10 @@ export class Document extends HasProvider implements IFile, HasMimeType {
 			new Dependency<void>(promiseFn, (): [boolean, void] => {
 				return [this.persistenceSynced, undefined];
 			});
-		return this.whenSyncedPromise.getPromise();
+		return trackPromise(
+			`doc:whenSynced:${this.guid}`,
+			this.whenSyncedPromise.getPromise(),
+		);
 	}
 
 	async hasKnownPeers(): Promise<boolean> {
@@ -588,12 +573,13 @@ export class Document extends HasProvider implements IFile, HasMimeType {
 			await this.vault.modify(this.tfile, contents);
 			this.warn("file saved", this.path);
 
-			// Notify HSM of save completion with new mtime and hash
-			if (this._hsm && this.tfile) {
+			// Notify HSM of save completion with new mtime and hash.
+			// Use optional chaining so async save tails don't emit after teardown.
+			if (this.tfile) {
 				const mtime = this.tfile.stat.mtime;
 				const encoder = new TextEncoder();
 				const hash = await generateHash(encoder.encode(contents).buffer);
-				this._hsm.send({ type: "SAVE_COMPLETE", mtime, hash });
+				this._hsm?.send({ type: "SAVE_COMPLETE", mtime, hash });
 			}
 		} finally {
 			this._isSaving = false;
@@ -629,9 +615,7 @@ export class Document extends HasProvider implements IFile, HasMimeType {
 		});
 
 		// Release HSM lock if held
-		if (this._hsm) {
-			this.releaseLock();
-		}
+		this.releaseLock();
 
 		super.destroy();
 		// Note: super.destroy() calls destroyRemoteDoc() which handles ydoc cleanup.
@@ -640,6 +624,7 @@ export class Document extends HasProvider implements IFile, HasMimeType {
 		this.whenSyncedPromise = null as any;
 		this.readyPromise?.destroy();
 		this.readyPromise = null as any;
+		this._hsm = null;
 		this._parent = null as any;
 	}
 
@@ -668,10 +653,16 @@ export class Document extends HasProvider implements IFile, HasMimeType {
 	 * Read current disk content for the HSM.
 	 * Used as diskLoader callback when creating HSM.
 	 */
-	async readDiskContent(): Promise<{ content: string; hash: string; mtime: number }> {
+	async readDiskContent(): Promise<{
+		content: string;
+		hash: string;
+		mtime: number;
+	}> {
 		const tfile = this.tfile;
 		if (!tfile) {
-			throw new Error(`[Document] Cannot read disk content for ${this.path}: TFile not found`);
+			throw new Error(
+				`[Document] Cannot read disk content for ${this.path}: TFile not found`,
+			);
 		}
 		const content = await this.vault.read(tfile);
 		const encoder = new TextEncoder();
@@ -683,7 +674,9 @@ export class Document extends HasProvider implements IFile, HasMimeType {
 	 * Handle effects emitted by the HSM.
 	 * Called by HSM subscriber in ensureHSM().
 	 */
-	async handleEffect(effect: import("./merge-hsm/types").MergeEffect): Promise<void> {
+	async handleEffect(
+		effect: import("./merge-hsm/types").MergeEffect,
+	): Promise<void> {
 		switch (effect.type) {
 			case "WRITE_DISK":
 				await this.handleWriteDisk(effect.contents, effect.mtime);
@@ -695,14 +688,20 @@ export class Document extends HasProvider implements IFile, HasMimeType {
 		}
 	}
 
-	private async handleWriteDisk(contents: string, mtime?: number): Promise<void> {
+	private async handleWriteDisk(
+		contents: string,
+		mtime?: number,
+	): Promise<void> {
 		const tfile = this.tfile;
 		if (!tfile) {
 			this.warn("[handleEffect:WRITE_DISK] TFile not found, cannot write");
 			return;
 		}
 		if (this.sharedFolder.isPendingDelete(this.path)) {
-			this.warn("[handleEffect:WRITE_DISK] Skipping write for pending delete", this.path);
+			this.warn(
+				"[handleEffect:WRITE_DISK] Skipping write for pending delete",
+				this.path,
+			);
 			return;
 		}
 
@@ -712,18 +711,23 @@ export class Document extends HasProvider implements IFile, HasMimeType {
 			await this.vault.modify(tfile, contents, options);
 			this.debug?.("[handleEffect:WRITE_DISK] Wrote to disk", this.path);
 
-			// Notify HSM of save completion with new mtime and hash
-			if (this._hsm) {
-				const encoder = new TextEncoder();
-				const hash = await generateHash(encoder.encode(contents).buffer);
-				this._hsm.send({ type: "SAVE_COMPLETE", mtime: tfile.stat.mtime, hash });
-			}
+			// Notify HSM of save completion with new mtime and hash.
+			// Use optional chaining so async write tails don't emit after teardown.
+			const encoder = new TextEncoder();
+			const hash = await generateHash(encoder.encode(contents).buffer);
+			this._hsm?.send({
+				type: "SAVE_COMPLETE",
+				mtime: tfile.stat.mtime,
+				hash,
+			});
 		} finally {
 			this._isSaving = false;
 		}
 	}
 
-	private async handlePersistState(_state: import("./merge-hsm/types").PersistedMergeState): Promise<void> {
+	private async handlePersistState(
+		_state: import("./merge-hsm/types").PersistedMergeState,
+	): Promise<void> {
 		// MergeManager.handleHSMEffect handles both LCA cache updates
 		// and IDB persistence via onEffect. No action needed here —
 		// Document's subscriber exists for other effect types only.
@@ -739,7 +743,8 @@ export class Document extends HasProvider implements IFile, HasMimeType {
 	 * when the provider is no longer needed (e.g. on hibernate).
 	 */
 	async connectForForkReconcile(): Promise<void> {
-		if (!this._hsm) return;
+		const hsm = this._hsm;
+		if (!hsm) return;
 		if (!this.sharedFolder.shouldConnect) return;
 
 		// Only tear down and recreate when there is an active fork that
@@ -748,10 +753,10 @@ export class Document extends HasProvider implements IFile, HasMimeType {
 		// would corrupt fork-reconcile's 3-way merge. When no fork is
 		// active (e.g. idle.diverged download path), preserve the working
 		// provider to avoid destroying a synced connection.
-		const hasFork = this._hsm.hasFork?.() ?? false;
+		const hasFork = hsm.hasFork();
 		if (hasFork) {
 			const result = reconnectProvider({
-				hsm: this._hsm,
+				hsm,
 				integration: this._providerIntegration,
 				createFreshRemoteDoc: () => this.ensureRemoteDoc(),
 				destroyCurrentRemoteDoc: () => this.destroyRemoteDoc(),
@@ -767,33 +772,31 @@ export class Document extends HasProvider implements IFile, HasMimeType {
 			return;
 		} else {
 			const remoteDoc = this.ensureRemoteDoc();
-			this._hsm.setRemoteDoc(remoteDoc);
+			hsm.setRemoteDoc(remoteDoc);
 
 			await this.connect();
 
-			if (!this._provider || !this._hsm) return;
+			// HSM can be nulled during teardown while connect() is in flight.
+			if (!this._provider || this._hsm !== hsm) return;
 
 			this._providerIntegration = new ProviderIntegration(
-				this._hsm,
+				hsm,
 				remoteDoc,
 				this._provider as YjsProvider,
 			);
 		}
 
-		if (this._hsm) {
-
-			// Tear down when transitioning to another idle state (fork resolved
-			// or diverged). Don't tear down when transitioning to active —
-			// acquireLock adopts the existing provider and ProviderIntegration.
-			const unsub = this._hsm.onStateChange(() => {
-				if (!this._hsm?.matches("idle.localAhead")) {
-					unsub();
-					if (!this._hsm?.isActive()) {
-						this.destroyIdleProviderIntegration();
-					}
+		// Tear down when transitioning to another idle state (fork resolved
+		// or diverged). Don't tear down when transitioning to active —
+		// acquireLock adopts the existing provider and ProviderIntegration.
+		const unsub = hsm.onStateChange(() => {
+			if (!hsm.matches("idle.localAhead")) {
+				unsub();
+				if (!hsm.isActive()) {
+					this.destroyIdleProviderIntegration();
 				}
-			});
-		}
+			}
+		});
 	}
 
 	/**
@@ -815,5 +818,4 @@ export class Document extends HasProvider implements IFile, HasMimeType {
 	hasProviderIntegration(): boolean {
 		return this._providerIntegration !== null;
 	}
-
 }

--- a/src/Document.ts
+++ b/src/Document.ts
@@ -500,13 +500,11 @@ export class Document extends HasProvider implements IFile, HasMimeType {
 	}
 
 	public get ready(): boolean {
-		if (!this._persistence) return this.synced;
-		return this._persistence.isReady(this.synced);
+		return this.persistenceSynced && this._awaitingUpdates === false;
 	}
 
 	hasLocalDB(): boolean {
-		if (!this._persistence) return false;
-		return this._persistence.hasServerSync || this._persistence.hasUserData();
+		return this._hsm?.hasPersistenceUserData() ?? false;
 	}
 
 	async awaitingUpdates(): Promise<boolean> {
@@ -527,6 +525,7 @@ export class Document extends HasProvider implements IFile, HasMimeType {
 
 	async whenReady(): Promise<Document> {
 		const promiseFn = async (): Promise<Document> => {
+			await this.whenSynced();
 			const awaitingUpdates = await this.awaitingUpdates();
 			if (awaitingUpdates) {
 				// If this is a brand new shared folder, we want to wait for a connection before we start reserving new guids for local files.
@@ -536,7 +535,7 @@ export class Document extends HasProvider implements IFile, HasMimeType {
 				this.log("connected");
 				await this.onceProviderSynced();
 				this.log("synced");
-				return this;
+				this._awaitingUpdates = false;
 			}
 			return this;
 		};
@@ -551,24 +550,8 @@ export class Document extends HasProvider implements IFile, HasMimeType {
 	whenSynced(): Promise<void> {
 		const promiseFn = async (): Promise<void> => {
 			await this.sharedFolder.whenSynced();
-
-			return new Promise<void>((resolve) => {
-				if (this.persistenceSynced) {
-					resolve();
-					return;
-				}
-
-				if (!this._persistence) {
-					this.persistenceSynced = true;
-					resolve();
-					return;
-				}
-
-				this._persistence.once("synced", () => {
-					this.persistenceSynced = true;
-					resolve();
-				});
-			});
+			await this._hsm?.awaitPersistenceReady();
+			this.persistenceSynced = true;
 		};
 
 		this.whenSyncedPromise =
@@ -628,13 +611,11 @@ export class Document extends HasProvider implements IFile, HasMimeType {
 	requestSave = debounce(this.save, 2000);
 
 	async markSynced(): Promise<void> {
-		if (!this._persistence) return;
-		await this._persistence.markServerSynced();
+		await this._hsm?.markPersistenceServerSynced();
 	}
 
 	async getServerSynced(): Promise<boolean> {
-		if (!this._persistence) return false;
-		return this._persistence.getServerSynced();
+		return (await this._hsm?.getPersistenceServerSynced()) ?? false;
 	}
 
 	static checkExtension(vpath: string): boolean {

--- a/src/LiveViews.ts
+++ b/src/LiveViews.ts
@@ -8,6 +8,7 @@ import {
 	Workspace,
 	editorInfoField,
 	moment,
+	type WorkspaceLeaf,
 	type CachedMetadata,
 } from "obsidian";
 import ViewActions from "src/components/ViewActions.svelte";
@@ -40,15 +41,21 @@ import { AwarenessViewPlugin } from "./AwarenessViewPlugin";
 import { TextFileViewPlugin } from "./TextViewPlugin";
 import { ViewHookPlugin } from "./plugins/ViewHookPlugin";
 import { DiskBuffer } from "./DiskBuffer";
+import { trackPromise } from "./trackPromise";
 
 /**
  * Access the LiveViewManager singleton via the Obsidian plugin registry.
  * Replaces ConnectionManagerStateField — no CM6 state field needed since
  * the plugin is a singleton reachable from any EditorView.
  */
-export function getConnectionManager(editor: EditorView): LiveViewManager | null {
+export function getConnectionManager(
+	editor: EditorView,
+): LiveViewManager | null {
 	const fileInfo = editor.state.field(editorInfoField, false);
-	return (fileInfo as any)?.app?.plugins?.plugins?.["system3-relay"]?._liveViews ?? null;
+	return (
+		(fileInfo as any)?.app?.plugins?.plugins?.["system3-relay"]?._liveViews ??
+		null
+	);
 }
 
 const BACKGROUND_CONNECTIONS = 3;
@@ -87,12 +94,12 @@ function iterateTextFileViews(
 		if (leaf.view instanceof TextFileView) {
 			const viewType = leaf.view.getViewType();
 			if (viewType === "canvas") return;
-			if (ALLOWED_TEXT_FILE_VIEWS.contains(viewType)) {
-				fn(leaf.view);
+				if (ALLOWED_TEXT_FILE_VIEWS.includes(viewType)) {
+					fn(leaf.view);
+				}
 			}
-		}
-	});
-}
+		});
+	}
 
 function ViewsetsEqual(vs1: S3View[], vs2: S3View[]): boolean {
 	if (vs1.length !== vs2.length) {
@@ -318,8 +325,10 @@ export class RelayCanvasView implements S3View {
 		}
 
 		return new Promise((resolve) => {
-			return this.canvas
-				.whenReady()
+			return trackPromise(
+				`canvasView:whenReady:${this.canvas.guid}`,
+				this.canvas.whenReady(),
+			)
 				.then((doc) => {
 					if (
 						this._parent.networkStatus.online &&
@@ -393,6 +402,7 @@ export class LiveView<ViewType extends TextFileView>
 	_tracking: boolean;
 	private _awarenessPlugin?: AwarenessViewPlugin;
 	private _hsmStateUnsubscribe?: () => void;
+	private _hasLock = false;
 
 	constructor(
 		connectionManager: LiveViewManager,
@@ -597,8 +607,8 @@ export class LiveView<ViewType extends TextFileView>
 						localOnly: this.document.hsm?.isLocalOnly ?? false,
 						enableDraftMode: flags().enableDraftMode,
 						folderConnected: this.document.sharedFolder.connected,
-						pendingOutbound: this.document.hsm!.pendingOutbound,
-						pendingInbound: this.document.hsm!.pendingInbound,
+						pendingOutbound: this.document.hsm?.pendingOutbound ?? 0,
+						pendingInbound: this.document.hsm?.pendingInbound ?? 0,
 					},
 				});
 				this.offConnectionStatusSubscription = this.document.subscribe(
@@ -612,8 +622,8 @@ export class LiveView<ViewType extends TextFileView>
 							localOnly: this.document.hsm?.isLocalOnly ?? false,
 							enableDraftMode: flags().enableDraftMode,
 							folderConnected: this.document.sharedFolder.connected,
-							pendingOutbound: this.document.hsm!.pendingOutbound,
-							pendingInbound: this.document.hsm!.pendingInbound,
+							pendingOutbound: this.document.hsm?.pendingOutbound ?? 0,
+							pendingInbound: this.document.hsm?.pendingInbound ?? 0,
 						});
 					},
 				);
@@ -628,15 +638,19 @@ export class LiveView<ViewType extends TextFileView>
 						localOnly: this.document.hsm?.isLocalOnly ?? false,
 						enableDraftMode: flags().enableDraftMode,
 						folderConnected: this.document.sharedFolder.connected,
-						pendingOutbound: this.document.hsm!.pendingOutbound,
-						pendingInbound: this.document.hsm!.pendingInbound,
+						pendingOutbound: this.document.hsm?.pendingOutbound ?? 0,
+						pendingInbound: this.document.hsm?.pendingInbound ?? 0,
 					});
 					const isConflict = state.statePath.includes("conflict");
 					if (isConflict && !this._banner) {
-						this.log("[LiveView] HSM entered conflict state, showing merge banner");
+						this.log(
+							"[LiveView] HSM entered conflict state, showing merge banner",
+						);
 						this.mergeBanner();
 					} else if (!isConflict && this._banner) {
-						this.log("[LiveView] HSM exited conflict state, hiding merge banner");
+						this.log(
+							"[LiveView] HSM exited conflict state, hiding merge banner",
+						);
 						this._banner.destroy();
 						this._banner = undefined;
 					}
@@ -650,8 +664,8 @@ export class LiveView<ViewType extends TextFileView>
 				localOnly: this.document.hsm?.isLocalOnly ?? false,
 				enableDraftMode: flags().enableDraftMode,
 				folderConnected: this.document.sharedFolder.connected,
-				pendingOutbound: this.document.hsm!.pendingOutbound,
-				pendingInbound: this.document.hsm!.pendingInbound,
+				pendingOutbound: this.document.hsm?.pendingOutbound ?? 0,
+				pendingInbound: this.document.hsm?.pendingInbound ?? 0,
 			});
 		}
 	}
@@ -696,32 +710,32 @@ export class LiveView<ViewType extends TextFileView>
 		}
 	}
 
+	private initializeEditorIntegration(): void {
+		if (!(this.view instanceof MarkdownView)) {
+			return;
+		}
+		const cm = (this.view.editor as any)?.cm as EditorView | undefined;
+		if (!cm) {
+			return;
+		}
+		const plugin = cm.plugin(HSMEditorPlugin);
+		plugin?.initializeIfReady();
+	}
+
 	attach(): Promise<this> {
 		// can be called multiple times, whereas release is only ever called once
-		// Use HSM acquireLock if available, otherwise falls back to userLock internally
-		// Pass view as EditorViewRef so HSM can read the live dirty flag
-		const viewRef: EditorViewRef = this.view as unknown as EditorViewRef;
-		this.document
-			.acquireLock(undefined, viewRef)
-			.then(() => {
-				// Refresh ViewActions after lock acquired — HSM may have
-				// reached active.tracking during the async acquireLock.
-				this.setConnectionDot();
-
-				// Push-initialize CM6Integration now that the document is ready.
-				// This replaces the polling approach (every CM6 update()) with a
-				// single targeted call when acquireLock completes.
-				if (this.view instanceof MarkdownView) {
-					const cm = (this.view.editor as any)?.cm as EditorView;
-					if (cm) {
-						const plugin = cm.plugin(HSMEditorPlugin);
-						plugin?.initializeIfReady();
-					}
-				}
-			})
-			.catch((e) => {
-				this.warn("[LiveView.attach] acquireLock failed:", e);
-			});
+		// Acquire a lock synchronously. Subsequent attach calls for the same view
+		// are idempotent until release().
+		if (!this._hasLock) {
+			this._parent.acquireDocumentLock(
+				this.document,
+				this.view as unknown as EditorViewRef,
+				this.view.leaf ?? undefined,
+				this.view.getViewData(),
+			);
+			this._hasLock = true;
+		}
+		this.initializeEditorIntegration();
 
 		// Add CSS class to indicate this view should have live editing
 		if (this.view instanceof MarkdownView) {
@@ -763,11 +777,14 @@ export class LiveView<ViewType extends TextFileView>
 		}
 
 		return new Promise((resolve) => {
-			return this.document
-				.whenReady()
-				.then((doc) => {
-					if (
-						this._parent.networkStatus.online &&
+				return trackPromise(
+					`liveView:whenReady:${this.document.guid}`,
+					this.document.whenReady(),
+				)
+					.then((doc) => {
+						this.initializeEditorIntegration();
+						if (
+							this._parent.networkStatus.online &&
 						this.document.sharedFolder.shouldConnect &&
 						this.shouldConnect &&
 						this.canConnect
@@ -790,6 +807,9 @@ export class LiveView<ViewType extends TextFileView>
 
 	release() {
 		// Called when a view is released from management
+		if (!this.document || !this.view) {
+			return;
+		}
 
 		// Remove the live editor class
 		if (this.view instanceof MarkdownView) {
@@ -815,8 +835,19 @@ export class LiveView<ViewType extends TextFileView>
 		this._viewHookPlugin = undefined;
 		this._plugin?.destroy();
 		this._plugin = undefined;
-		this.document.disconnect();
-		this.document.releaseLock();
+		const sharedFolder = this.document.sharedFolder;
+		const preservePendingUpload =
+			!!sharedFolder && sharedFolder.isPendingUpload(this.document.path);
+		if (!preservePendingUpload) {
+			this.document.disconnect();
+		}
+		if (this._hasLock) {
+			this._parent.releaseDocumentLock(
+				this.document,
+				this.view.leaf ?? undefined,
+			);
+			this._hasLock = false;
+		}
 	}
 
 	destroy() {
@@ -846,6 +877,7 @@ export class LiveViewManager {
 	extensions: Extension[];
 	networkStatus: NetworkStatus;
 	refreshQueue: (() => Promise<boolean>)[];
+	private documentLockHolders: Map<string, Set<WorkspaceLeaf>>;
 	log: (message: string, ...args: unknown[]) => void;
 	warn: (message: string, ...args: unknown[]) => void;
 
@@ -863,6 +895,7 @@ export class LiveViewManager {
 		this.loginManager = loginManager;
 		this.networkStatus = networkStatus;
 		this.refreshQueue = [];
+		this.documentLockHolders = new Map();
 
 		this.log = curryLog("[LiveViews]", "log");
 		this.warn = curryLog("[LiveViews]", "warn");
@@ -887,8 +920,10 @@ export class LiveViewManager {
 		const folderSub = (folder: SharedFolder) => {
 			if (!folder.ready) {
 				(async () => {
-					folder
-						.whenReady()
+					trackPromise(
+						`liveViews:folderReady:${folder.guid}`,
+						folder.whenReady(),
+					)
 						.then(() => {
 							this.refresh("[Shared Folder Ready]");
 						})
@@ -957,6 +992,85 @@ export class LiveViewManager {
 		return this.views.some((view) => view.document === doc);
 	}
 
+	private isDocumentOpenInWorkspace(document: Document): boolean {
+		const sharedFolder = document.sharedFolder;
+		if (!sharedFolder) return false;
+		const fullPath = sharedFolder.getPath(document.path);
+		let open = false;
+		this.workspace.iterateAllLeaves((leaf) => {
+			if (open) return;
+			if ((leaf.view as any)?.file?.path === fullPath) {
+				open = true;
+			}
+		});
+		return open;
+	}
+
+	acquireDocumentLock(
+		document: Document,
+		editorViewRef: EditorViewRef,
+		lockHolder: WorkspaceLeaf | undefined,
+		editorContent: string,
+	): void {
+		if (!lockHolder) {
+			document.userLock = true;
+			document.acquireLock(editorContent, editorViewRef);
+			return;
+		}
+
+		let holders = this.documentLockHolders.get(document.guid);
+		if (!holders) {
+			holders = new Set();
+			this.documentLockHolders.set(document.guid, holders);
+		}
+
+		const wasEmpty = holders.size === 0;
+		holders.add(lockHolder);
+		document.userLock = true;
+
+		if (wasEmpty) {
+			document.acquireLock(editorContent, editorViewRef);
+		}
+	}
+
+	releaseDocumentLock(document: Document, lockHolder?: WorkspaceLeaf): void {
+		if (!lockHolder) {
+			this.documentLockHolders.delete(document.guid);
+			if (this.isDocumentOpenInWorkspace(document)) {
+				document.userLock = true;
+				return;
+			}
+			document.userLock = false;
+			document.releaseLock();
+			return;
+		}
+
+		const holders = this.documentLockHolders.get(document.guid);
+		if (!holders) {
+			if (this.isDocumentOpenInWorkspace(document)) {
+				document.userLock = true;
+				return;
+			}
+			document.userLock = false;
+			document.releaseLock();
+			return;
+		}
+
+		holders.delete(lockHolder);
+		if (holders.size > 0) {
+			document.userLock = true;
+			return;
+		}
+
+		this.documentLockHolders.delete(document.guid);
+		if (this.isDocumentOpenInWorkspace(document)) {
+			document.userLock = true;
+			return;
+		}
+		document.userLock = false;
+		document.releaseLock();
+	}
+
 	/**
 	 * Notify MergeManagers which documents have open editors.
 	 * Groups views by their shared folder and calls setActiveDocuments() on each.
@@ -966,7 +1080,9 @@ export class LiveViewManager {
 	 * documents have open editors. MergeManager fans out SET_MODE_ACTIVE to those HSMs,
 	 * and SET_MODE_IDLE to all others.
 	 */
-	private async updateMergeManagerActiveDocuments(views: S3View[]): Promise<void> {
+	private async updateMergeManagerActiveDocuments(
+		views: S3View[],
+	): Promise<void> {
 		// Group document GUIDs by their shared folder
 		const folderToGuids = new Map<SharedFolder, Set<string>>();
 
@@ -1030,7 +1146,11 @@ export class LiveViewManager {
 
 	private releaseViews(views: S3View[]) {
 		views.forEach((view) => {
-			view.release();
+			try {
+				view.release();
+			} catch (e) {
+				this.warn("[LiveViews] error releasing stale view", e);
+			}
 		});
 	}
 
@@ -1091,7 +1211,9 @@ export class LiveViewManager {
 		if (folders.size === 0) {
 			return [];
 		}
-		const readyFolders = [...folders].map((folder) => folder.whenReady());
+		const readyFolders = [...folders].map((folder) =>
+			trackPromise(`liveViews:findFolders:${folder.guid}`, folder.whenReady()),
+		);
 		return Promise.all(readyFolders);
 	}
 
@@ -1227,10 +1349,38 @@ export class LiveViewManager {
 		);
 	}
 
+	private getExpectedViewPath(document: S3View["document"]): string | null {
+		if (!document?.path) {
+			return null;
+		}
+		const sharedFolder = document.sharedFolder;
+		if (!sharedFolder) {
+			return null;
+		}
+		return sharedFolder.getPath(document.path);
+	}
+
 	private deduplicate(views: S3View[]): [S3View[], S3View[]] {
 		const stale: S3View[] = [];
 		const matching: S3View[] = [];
 		this.views.forEach((oldView) => {
+			const viewPath = oldView.view?.file?.path;
+			const expectedViewPath = this.getExpectedViewPath(oldView.document);
+			if (
+				oldView.document?.path &&
+				viewPath &&
+				expectedViewPath &&
+				viewPath !== expectedViewPath
+			) {
+				this.warn("[LiveViews] stale view path mismatch", {
+					viewPath,
+					expectedViewPath,
+					documentPath: oldView.document.path,
+					viewType: oldView.view.getViewType?.(),
+				});
+				stale.push(oldView);
+				return;
+			}
 			const found = views.find((newView) => {
 				if (
 					oldView.document == newView.document &&
@@ -1385,6 +1535,8 @@ export class LiveViewManager {
 		this.folderListeners.forEach((off) => off());
 		this.folderListeners.clear();
 		this.folderListeners = null as any;
+		this.documentLockHolders.clear();
+		this.documentLockHolders = null as any;
 		this.views.forEach((view) => view.destroy());
 		this.views = [];
 		this.wipe();
@@ -1397,4 +1549,3 @@ export class LiveViewManager {
 		this.workspace = null as any;
 	}
 }
-

--- a/src/RelayDebugAPI.ts
+++ b/src/RelayDebugAPI.ts
@@ -313,6 +313,7 @@ export class RelayDebugAPI {
   private bridges = new Map<string, E2ERecordingBridge>();
   private activeRecordingName: string | null = null;
   private plugin: any;
+  private destroyed = false;
 
   constructor(plugin?: any) {
     this.plugin = plugin;
@@ -324,6 +325,11 @@ export class RelayDebugAPI {
    * Returns a cleanup function to call when the folder is destroyed.
    */
   registerBridge(folderPath: string, bridge: E2ERecordingBridge): () => void {
+    if (this.destroyed) {
+      return () => {
+        bridge.dispose();
+      };
+    }
     this.bridges.set(folderPath, bridge);
 
     // Auto-start recording if one is currently active
@@ -338,7 +344,9 @@ export class RelayDebugAPI {
     return () => {
       bridge.dispose();
       this.bridges.delete(folderPath);
-      this.installGlobal();
+      if (!this.destroyed) {
+        this.installGlobal();
+      }
     };
   }
 
@@ -347,6 +355,12 @@ export class RelayDebugAPI {
    */
   private installGlobal(): void {
     const g = typeof window !== 'undefined' ? window : globalThis;
+    if (this.destroyed) {
+      if ((g as any).__relayDebug?.__owner === this) {
+        delete (g as any).__relayDebug;
+      }
+      return;
+    }
 
     const api: RelayDebugGlobal = {
       startRecording: (name) => {
@@ -537,6 +551,7 @@ export class RelayDebugAPI {
     };
 
     (g as any).__relayDebug = {
+      __owner: this,
       ...api,
       registerBridge: (folderPath: string, bridge: E2ERecordingBridge) => this.registerBridge(folderPath, bridge),
     };
@@ -1237,14 +1252,21 @@ export class RelayDebugAPI {
    * Call in plugin onunload().
    */
   destroy(): void {
+    if (this.destroyed) {
+      return;
+    }
+    this.destroyed = true;
     for (const bridge of this.bridges.values()) {
       bridge.dispose();
     }
     this.bridges.clear();
     this.activeRecordingName = null;
+    this.plugin = null;
 
     const g = typeof window !== 'undefined' ? window : globalThis;
-    delete (g as any).__relayDebug;
+    if ((g as any).__relayDebug?.__owner === this) {
+      delete (g as any).__relayDebug;
+    }
   }
 }
 

--- a/src/RelayDebugAPI.ts
+++ b/src/RelayDebugAPI.ts
@@ -961,8 +961,8 @@ export class RelayDebugAPI {
       lcaHash: lca?.meta?.hash || null,
       lcaContentLength: lca?.contents?.length ?? null,
       lcaContent,
-      hasConflict: !!(hsm as any).conflictData,
-      conflictData: (hsm as any).conflictData || null,
+      hasConflict: !!(hsm as any).getConflictData?.(),
+      conflictData: (hsm as any).getConflictData?.() || null,
       localDocLength: (hsm as any).localDoc
         ? ((hsm as any).localDoc.getText?.('contents')?.toString()?.length ?? 0)
         : 0,
@@ -1071,7 +1071,10 @@ export class RelayDebugAPI {
     if (!lookup) throw new Error(`HSM not found: ${path}`);
     const { hsm, guid } = lookup;
 
-    const cd = (hsm as any).conflictData || null;
+    // `getConflictData` derives on-demand from current HSM materials when
+    // there's no live resolution session — diverged docs without an open
+    // banner still report correct hunks.
+    const cd = (hsm as any).getConflictData?.() || null;
     const regions = (cd?.conflictRegions as any[] | undefined) ?? [];
     const resolved = (cd?.resolvedIndices as Set<number> | undefined) ?? new Set<number>();
 
@@ -1170,7 +1173,7 @@ export class RelayDebugAPI {
     if (typeof indexOrId === 'number') {
       index = indexOrId;
     } else {
-      const cd = hsm.conflictData;
+      const cd = hsm.getConflictData?.();
       if (!cd?.conflictRegions) {
         throw new Error(`No active conflict on ${path}`);
       }

--- a/src/RelayDebugAPI.ts
+++ b/src/RelayDebugAPI.ts
@@ -198,7 +198,45 @@ export interface HsmStateSnapshot {
 // Global interface exposed via CDP
 // =============================================================================
 
+/**
+ * A stable reference to an editor leaf. Resolved by matching windowId+leafId;
+ * operations that require the leaf to still be showing the same file verify
+ * `handle.path` against the leaf's current file.
+ */
+export interface EditorHandle {
+  windowId: string;
+  leafId: string;
+  path: string;
+}
+
+export interface OpenEditorResult {
+  handle: EditorHandle;
+  viewType: string | null;
+  mode: string | null;
+}
+
+export interface EditorInfo {
+  handle: EditorHandle;
+  /** The leaf's current file path. Differs from handle.path if the leaf drifted. Null if the leaf is gone. */
+  currentPath: string | null;
+  viewType: string | null;
+  mode: string | null;
+  active: boolean;
+}
+
+export type SetEditorContentResult =
+  | { success: true; changeCount: number }
+  | { success: false; error: string };
+
 export interface RelayDebugGlobal {
+  /** Open PATH in an editor leaf. Pass `{ newLeaf: true }` to force a new tab. */
+  openEditor: (path: string, opts?: { newLeaf?: boolean }) => Promise<OpenEditorResult>;
+  /** Close the exact leaf identified by HANDLE. No-op if already gone. */
+  closeEditor: (handle: EditorHandle) => Promise<void>;
+  /** Read the editor text from the exact leaf. Throws if the leaf drifted. */
+  getEditorContent: (handle: EditorHandle) => Promise<string>;
+  /** Inspect a handle without mutating focus or throwing on drift. */
+  getEditorInfo: (handle: EditorHandle) => EditorInfo;
   /** Start recording all HSM activity */
   startRecording: (name?: string) => E2ERecordingState;
   /** Stop recording and return lightweight summary JSON */
@@ -221,8 +259,8 @@ export interface RelayDebugGlobal {
   getSessionLogs: (options?: SessionLogOptions) => Promise<object[]>;
   /** Get a snapshot of all content views for a document */
   getDocumentContent: (path: string) => Promise<DocumentContentSnapshot>;
-  /** Set the active editor's content via minimal CM6 transactions (simulates user typing) */
-  setEditorContent: (content: string) => { success: boolean; changeCount: number } | { error: string };
+  /** Set the editor text via minimal CM6 transactions. Throws if the leaf drifted. */
+  setEditorContent: (handle: EditorHandle, content: string) => Promise<SetEditorContentResult>;
   /** Look up a document by vault-scoped path (e.g. "private/foo.md"). Returns document, HSM, folder, and GUID. */
   lookupDocument: (path: string) => { doc: any; hsm: any; guid: string; folder: any; filePath: string } | null;
   /** Look up a shared folder by path (e.g. "private"). Returns the SharedFolder or null. */
@@ -436,6 +474,10 @@ export class RelayDebugAPI {
       getRecentEntries: (guid, limit) => getRecentEntries(guid, limit),
       readIdbContent: readIdbContent,
       getSessionLogs: (options) => getSessionLogs(options),
+      openEditor: (path, opts) => this.openEditor(path, opts),
+      closeEditor: (handle) => this.closeEditor(handle),
+      getEditorContent: (handle) => this.getEditorContent(handle),
+      getEditorInfo: (handle) => this.getEditorInfo(handle),
       getDocumentContent: async (path) => this.getDocumentContent(path),
       getHsmStateSnapshot: async (path) => this.getHsmStateSnapshot(path),
       getIdbContent: async (path) => this.getIdbContent(path),
@@ -453,51 +495,7 @@ export class RelayDebugAPI {
       getPendingPromises: () => this.plugin?.promises?.getPending() ?? [],
       getRecentPromises: () => getRecentPromises(),
 
-      setEditorContent: (content: string) => {
-        const editor = (this.plugin?.app as any)?.workspace?.activeEditor?.editor;
-        if (!editor) return { error: 'No active editor' };
-        const cm = editor.cm;
-        if (!cm) return { error: 'No CM6 EditorView' };
-
-        const before = cm.state.doc.toString();
-        if (before === content) return { success: true, changeCount: 0 };
-
-        const dmp = new diff_match_patch();
-        const diffs = dmp.diff_main(before, content);
-        dmp.diff_cleanupSemantic(diffs);
-
-        const changes: { from: number; to: number; insert: string }[] = [];
-        let pos = 0;
-        for (const [op, text] of diffs) {
-          if (op === 0) {
-            pos += text.length;
-          } else if (op === -1) {
-            changes.push({ from: pos, to: pos + text.length, insert: '' });
-            pos += text.length;
-          } else if (op === 1) {
-            changes.push({ from: pos, to: pos, insert: text });
-          }
-        }
-
-        // Merge adjacent delete+insert into replacements
-        const merged: typeof changes = [];
-        let i = 0;
-        while (i < changes.length) {
-          const cur = changes[i];
-          if (i + 1 < changes.length && cur.insert === '' &&
-              changes[i + 1].from === cur.to && changes[i + 1].to === changes[i + 1].from) {
-            merged.push({ from: cur.from, to: cur.to, insert: changes[i + 1].insert });
-            i += 2;
-          } else {
-            merged.push(cur);
-            i++;
-          }
-        }
-
-        // Dispatch without ySyncAnnotation so HSM treats this as a user edit
-        cm.dispatch({ changes: merged });
-        return { success: true, changeCount: merged.length };
-      },
+      setEditorContent: (handle, content) => this.setEditorContent(handle, content),
 
       lookupFolder: (path: string) => {
         if (!this.plugin?.sharedFolders?._set) return null;
@@ -555,6 +553,192 @@ export class RelayDebugAPI {
       ...api,
       registerBridge: (folderPath: string, bridge: E2ERecordingBridge) => this.registerBridge(folderPath, bridge),
     };
+  }
+
+  /**
+   * Locate the leaf identified by HANDLE.windowId + HANDLE.leafId. Does NOT
+   * verify the path — callers that require path match call resolveAndVerify.
+   */
+  private findLeaf(handle: EditorHandle): any | null {
+    let found: any = null;
+    this.plugin?.app?.workspace?.iterateAllLeaves?.((leaf: any) => {
+      if (found) return;
+      const ids = this.leafIds(leaf);
+      if (ids.windowId === handle.windowId && ids.leafId === handle.leafId) {
+        found = leaf;
+      }
+    });
+    return found;
+  }
+
+  /**
+   * Resolve the exact leaf for HANDLE and verify it still shows handle.path.
+   * Throws a precise error on every failure mode the caller cares about.
+   */
+  private resolveAndVerify(handle: EditorHandle): any {
+    const leaf = this.findLeaf(handle);
+    if (!leaf) {
+      throw new Error(`leaf not found: windowId=${handle.windowId} leafId=${handle.leafId}`);
+    }
+    const currentPath = leaf.view?.file?.path ?? null;
+    if (currentPath !== handle.path) {
+      throw new Error(`leaf drifted to ${currentPath ?? '<no file>'} (expected ${handle.path})`);
+    }
+    return leaf;
+  }
+
+  /**
+   * Stable IDs for a leaf. Uses Obsidian's internal leaf.id and derives a
+   * windowId from the leaf's root (main window vs popout).
+   */
+  private leafIds(leaf: any): { windowId: string; leafId: string } {
+    const leafId: string = leaf?.id ?? '';
+    const root = leaf?.getRoot?.();
+    const rootId: string | undefined = root?.id;
+    const mainRoot = this.plugin?.app?.workspace?.rootSplit;
+    let windowId: string;
+    if (!root || root === mainRoot) {
+      windowId = 'main';
+    } else if (rootId) {
+      windowId = `popout:${rootId}`;
+    } else {
+      // Fallback: identify by the window containing the leaf's DOM.
+      const ownerWin = leaf?.view?.containerEl?.ownerDocument?.defaultView;
+      windowId = ownerWin && ownerWin !== window ? 'popout:unknown' : 'main';
+    }
+    return { windowId, leafId };
+  }
+
+  private leafViewInfo(leaf: any): { viewType: string | null; mode: string | null; currentPath: string | null } {
+    const view = leaf?.view;
+    return {
+      viewType: view?.getViewType?.() ?? null,
+      mode: view?.getMode?.() ?? null,
+      currentPath: view?.file?.path ?? null,
+    };
+  }
+
+  private async openEditor(
+    path: string,
+    opts?: { newLeaf?: boolean },
+  ): Promise<OpenEditorResult> {
+    const file = this.plugin?.app?.vault?.getAbstractFileByPath(path);
+    if (!file) {
+      throw new Error(`File not found: ${path}`);
+    }
+    const leaf = this.plugin.app.workspace.getLeaf(opts?.newLeaf ? 'tab' : false);
+    await leaf.openFile(file);
+    this.plugin.app.workspace.setActiveLeaf?.(leaf, { focus: true });
+
+    // Markdown views default to preview; flip to source so the editor is live.
+    const view = leaf.view;
+    if (view?.getViewType?.() === 'markdown') {
+      if (typeof view.setMode === 'function') {
+        if (view.getMode?.() !== 'source') {
+          await view.setMode('source');
+        }
+      } else if (typeof leaf.setViewState === 'function') {
+        const state = leaf.getViewState?.() ?? { type: 'markdown', state: {} };
+        await leaf.setViewState({
+          ...state,
+          state: { ...(state.state || {}), file: path, mode: 'source' },
+        }, { focus: true });
+      }
+    }
+
+    const ids = this.leafIds(leaf);
+    const info = this.leafViewInfo(leaf);
+    return {
+      handle: { windowId: ids.windowId, leafId: ids.leafId, path },
+      viewType: info.viewType,
+      mode: info.mode,
+    };
+  }
+
+  private getEditorInfo(handle: EditorHandle): EditorInfo {
+    const leaf = this.findLeaf(handle);
+    if (!leaf) {
+      return {
+        handle,
+        currentPath: null,
+        viewType: null,
+        mode: null,
+        active: false,
+      };
+    }
+    const info = this.leafViewInfo(leaf);
+    const active = this.plugin?.app?.workspace?.activeLeaf === leaf;
+    return {
+      handle,
+      currentPath: info.currentPath,
+      viewType: info.viewType,
+      mode: info.mode,
+      active,
+    };
+  }
+
+  private async getEditorContent(handle: EditorHandle): Promise<string> {
+    const leaf = this.resolveAndVerify(handle);
+    const editor = leaf.view?.editor;
+    if (!editor) {
+      throw new Error(`leaf has no editor: ${handle.path}`);
+    }
+    return editor.getValue();
+  }
+
+  private async setEditorContent(
+    handle: EditorHandle,
+    content: string,
+  ): Promise<SetEditorContentResult> {
+    const leaf = this.resolveAndVerify(handle);
+    const editor = leaf.view?.editor;
+    const cm = editor?.cm;
+    if (!cm) return { success: false, error: 'leaf has no CM6 EditorView' };
+
+    const before = cm.state.doc.toString();
+    if (before === content) return { success: true, changeCount: 0 };
+
+    const dmp = new diff_match_patch();
+    const diffs = dmp.diff_main(before, content);
+    dmp.diff_cleanupSemantic(diffs);
+
+    const changes: { from: number; to: number; insert: string }[] = [];
+    let pos = 0;
+    for (const [op, text] of diffs) {
+      if (op === 0) {
+        pos += text.length;
+      } else if (op === -1) {
+        changes.push({ from: pos, to: pos + text.length, insert: '' });
+        pos += text.length;
+      } else if (op === 1) {
+        changes.push({ from: pos, to: pos, insert: text });
+      }
+    }
+
+    // Merge adjacent delete+insert into replacements
+    const merged: typeof changes = [];
+    let i = 0;
+    while (i < changes.length) {
+      const cur = changes[i];
+      if (i + 1 < changes.length && cur.insert === '' &&
+          changes[i + 1].from === cur.to && changes[i + 1].to === changes[i + 1].from) {
+        merged.push({ from: cur.from, to: cur.to, insert: changes[i + 1].insert });
+        i += 2;
+      } else {
+        merged.push(cur);
+        i++;
+      }
+    }
+
+    // Dispatch without ySyncAnnotation so HSM treats this as a user edit
+    cm.dispatch({ changes: merged });
+    return { success: true, changeCount: merged.length };
+  }
+
+  private async closeEditor(handle: EditorHandle): Promise<void> {
+    const leaf = this.findLeaf(handle);
+    if (!leaf) return; // already gone — no-op
+    leaf.detach?.();
   }
 
   /**

--- a/src/RelayDebugAPI.ts
+++ b/src/RelayDebugAPI.ts
@@ -265,6 +265,14 @@ export interface RelayDebugGlobal {
   lookupDocument: (path: string) => { doc: any; hsm: any; guid: string; folder: any; filePath: string } | null;
   /** Look up a shared folder by path (e.g. "private"). Returns the SharedFolder or null. */
   lookupFolder: (path: string) => any | null;
+  /** Folder-scoped sync rows from MergeManager.syncStatus keyed by guid. */
+  getFolderSyncStatus: (folderGuid: string) => { guid: string; path: string; status: string }[];
+  /** Folder-scoped subset of sync rows where status === "error". */
+  getFolderSyncErrors: (folderGuid: string) => { guid: string; path: string; status: string }[];
+  /** Folder-scoped subset of sync rows where status === "conflict". */
+  getFolderConflicts: (folderGuid: string) => { guid: string; path: string }[];
+  /** All files currently in conflict state across every shared folder. */
+  listAllConflicts: () => { folderGuid: string; folderPath: string; guid: string; path: string }[];
   /** Get a rich HSM state snapshot for the test harness — state path, LCA, disk, IDB, SV, frontmatter, recent transitions. */
   getHsmStateSnapshot: (path: string) => Promise<HsmStateSnapshot>;
   /** Snapshot the per-doc IndexedDB: updates count, custom metadata, IDB content, disk content, match flag. */
@@ -341,6 +349,11 @@ export interface RelayDebugGlobal {
   // -- Promise tracking --
   getPendingPromises: () => { label: string; ageMs: number; owner?: string }[];
   getRecentPromises: () => { label: string; created: number; settledAt: number; state: "fulfilled" | "rejected"; owner?: string }[];
+
+  // -- Relay server CRUD --
+  createRelay: (name: string) => Promise<{ guid: string; name: string }>;
+  renameRelay: (guid: string, newName: string) => Promise<{ guid: string; name: string }>;
+  deleteRelay: (guid: string) => Promise<boolean>;
 }
 
 // =============================================================================
@@ -495,6 +508,26 @@ export class RelayDebugAPI {
       getPendingPromises: () => this.plugin?.promises?.getPending() ?? [],
       getRecentPromises: () => getRecentPromises(),
 
+      createRelay: async (name) => {
+        if (!this.plugin.relayManager) throw new Error('RelayManager not available');
+        const relay = await this.plugin.relayManager.createRelay(name);
+        return { guid: relay.guid, name: relay.name };
+      },
+      renameRelay: async (guid, newName) => {
+        if (!this.plugin.relayManager) throw new Error('RelayManager not available');
+        const relay = this.findRelayByGuid(guid);
+        if (!relay) throw new Error(`Relay not found: ${guid}`);
+        relay.name = newName;
+        await this.plugin.relayManager.updateRelay(relay);
+        return { guid: relay.guid, name: relay.name };
+      },
+      deleteRelay: async (guid) => {
+        if (!this.plugin.relayManager) throw new Error('RelayManager not available');
+        const relay = this.findRelayByGuid(guid);
+        if (!relay) throw new Error(`Relay not found: ${guid}`);
+        return await this.plugin.relayManager.destroyRelay(relay);
+      },
+
       setEditorContent: (handle, content) => this.setEditorContent(handle, content),
 
       lookupFolder: (path: string) => {
@@ -508,18 +541,26 @@ export class RelayDebugAPI {
         }
         return null;
       },
+      getFolderSyncStatus: (folderGuid: string) => this.getFolderSyncStatus(folderGuid),
+      getFolderSyncErrors: (folderGuid: string) => this.getFolderSyncErrors(folderGuid),
+      getFolderConflicts: (folderGuid: string) => this.getFolderConflicts(folderGuid),
+      listAllConflicts: () => this.listAllConflicts(),
 
       lookupDocument: (path: string) => {
         if (!this.plugin?.sharedFolders?._set) return null;
+        if (!path.startsWith('/')) {
+          throw new Error(`Document paths must start with '/' (got: ${JSON.stringify(path)})`);
+        }
         const folders = Array.from(this.plugin.sharedFolders._set.values()) as any[];
 
-        // Resolve folder scope from vault path (e.g. "private/foo.md")
+        // Resolve folder scope from vault path (e.g. "/private/foo.md")
         let targetFolder: any = null;
         let relativePath = path;
         for (const folder of folders) {
-          if (path.startsWith(folder.path + '/')) {
+          const prefix = '/' + folder.path + '/';
+          if (path.startsWith(prefix)) {
             targetFolder = folder;
-            relativePath = path.slice(folder.path.length);
+            relativePath = path.slice(prefix.length - 1); // keep leading slash
             break;
           }
         }
@@ -618,6 +659,16 @@ export class RelayDebugAPI {
     };
   }
 
+  private findLeavesByPath(path: string): any[] {
+    const matches: any[] = [];
+    this.plugin?.app?.workspace?.iterateAllLeaves?.((leaf: any) => {
+      if (leaf?.view?.file?.path === path) {
+        matches.push(leaf);
+      }
+    });
+    return matches;
+  }
+
   private async openEditor(
     path: string,
     opts?: { newLeaf?: boolean },
@@ -646,8 +697,20 @@ export class RelayDebugAPI {
       }
     }
 
-    const ids = this.leafIds(leaf);
-    const info = this.leafViewInfo(leaf);
+    // Let Obsidian finish any async view replacement caused by mode switches.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const activeLeaf = this.plugin.app.workspace.activeLeaf;
+    const candidates = this.findLeavesByPath(path);
+    const resolvedLeaf = (
+      (activeLeaf?.view?.file?.path === path ? activeLeaf : null)
+      ?? candidates.find((candidate) => candidate === leaf)
+      ?? candidates[0]
+      ?? leaf
+    );
+
+    const ids = this.leafIds(resolvedLeaf);
+    const info = this.leafViewInfo(resolvedLeaf);
     return {
       handle: { windowId: ids.windowId, leafId: ids.leafId, path },
       viewType: info.viewType,
@@ -737,8 +800,17 @@ export class RelayDebugAPI {
 
   private async closeEditor(handle: EditorHandle): Promise<void> {
     const leaf = this.findLeaf(handle);
-    if (!leaf) return; // already gone — no-op
-    leaf.detach?.();
+    if (leaf && leaf?.view?.file?.path === handle.path) {
+      leaf.detach?.();
+      return;
+    }
+
+    // If the original leaf was rebuilt and its id drifted, close by path.
+    const matches = this.findLeavesByPath(handle.path);
+    if (matches.length === 0) return;
+    for (const match of matches) {
+      match.detach?.();
+    }
   }
 
   /**
@@ -1138,6 +1210,66 @@ export class RelayDebugAPI {
    * that reproduces the no-LCA state after upgrading from a plugin
    * version without LCA tracking.
    */
+  private findRelayByGuid(guid: string) {
+    for (const r of this.plugin.relayManager.relays._map.values()) {
+      if (r.guid === guid) return r;
+    }
+    return null;
+  }
+
+  private getFolderByGuid(folderGuid: string): any | null {
+    if (!this.plugin?.sharedFolders?._set) return null;
+    for (const folder of this.plugin.sharedFolders._set.values()) {
+      if ((folder as any).guid === folderGuid) return folder;
+    }
+    return null;
+  }
+
+  private getFolderSyncStatus(folderGuid: string): { guid: string; path: string; status: string }[] {
+    const folder = this.getFolderByGuid(folderGuid);
+    const mm = folder?.mergeManager;
+    if (!mm?.syncStatus) return [];
+
+    const rows: { guid: string; path: string; status: string }[] = [];
+    for (const [guid, syncStatus] of mm.syncStatus.entries()) {
+      const doc = mm._getDocument?.(guid);
+      rows.push({
+        guid,
+        path: doc?.path ?? guid,
+        status: syncStatus?.status ?? 'unknown',
+      });
+    }
+    rows.sort((a, b) => a.path.localeCompare(b.path));
+    return rows;
+  }
+
+  private getFolderSyncErrors(folderGuid: string): { guid: string; path: string; status: string }[] {
+    return this.getFolderSyncStatus(folderGuid).filter((row) => row.status === 'error');
+  }
+
+  private getFolderConflicts(folderGuid: string): { guid: string; path: string }[] {
+    return this.getFolderSyncStatus(folderGuid)
+      .filter((row) => row.status === 'conflict')
+      .map(({ guid, path }) => ({ guid, path }));
+  }
+
+  private listAllConflicts(): { folderGuid: string; folderPath: string; guid: string; path: string }[] {
+    if (!this.plugin?.sharedFolders?._set) return [];
+    const out: { folderGuid: string; folderPath: string; guid: string; path: string }[] = [];
+    for (const folder of this.plugin.sharedFolders._set.values() as Iterable<any>) {
+      const folderGuid = folder.guid;
+      const folderPath = folder.path ?? '';
+      for (const row of this.getFolderConflicts(folderGuid)) {
+        // Emit a vault-relative path with a leading slash so it round-trips
+        // through lookupDocument — copy/paste-friendly into `conflict info`.
+        const inner = row.path.replace(/^\/+/, '');
+        const fullPath = folderPath ? `/${folderPath}/${inner}` : `/${inner}`;
+        out.push({ folderGuid, folderPath, guid: row.guid, path: fullPath });
+      }
+    }
+    return out;
+  }
+
   private async clearLca(path: string): Promise<void> {
     const g = typeof window !== 'undefined' ? window : globalThis;
     const lookup = (g as any).__relayDebug?.lookupDocument?.(path);

--- a/src/SettingsStorage.ts
+++ b/src/SettingsStorage.ts
@@ -249,6 +249,15 @@ export class Settings<T> extends Observable<T> {
 			listener(this.data);
 		}
 	}
+
+	override destroy() {
+		if (this.destroyed) return;
+		super.destroy();
+		this.data = null as any;
+		this._loaded = false;
+		(this as any).storage = null;
+		(this as any).defaults = null;
+	}
 }
 
 export class NamespacedSettings<

--- a/src/ShareLinkPlugin.ts
+++ b/src/ShareLinkPlugin.ts
@@ -1,10 +1,11 @@
 import { Annotation, ChangeSet } from "@codemirror/state";
 import { EditorView, ViewPlugin } from "@codemirror/view";
 import type { PluginValue } from "@codemirror/view";
-import { TextFileView } from "obsidian";
-import { LiveView, LiveViewManager, getConnectionManager } from "./LiveViews";
 import { hasKey, updateFrontMatter } from "./Frontmatter";
 import { diffChars } from "diff";
+import { Document } from "./Document";
+import { getSharedFolders, getEditorFile } from "./editorContext";
+import { trackPromise } from "./trackPromise";
 
 export const shareLinkAnnotation = Annotation.define();
 
@@ -53,42 +54,49 @@ function diffToChangeSet(originalText: string, newText: string): ChangeSet {
 
 export class ShareLinkPluginValue implements PluginValue {
 	editor: EditorView;
-	view?: LiveView<TextFileView>;
-	connectionManager: LiveViewManager;
+	document?: Document;
 
 	constructor(editor: EditorView) {
 		this.editor = editor;
-		this.connectionManager = getConnectionManager(this.editor)!;
-		this.view = this.connectionManager.findView(editor);
-		this.editor = editor;
-		if (this.view) {
-			const hsm = this.view.document?.hsm;
+		this.document = this.resolveDocument();
+		if (this.document) {
+			const hsm = this.document.hsm;
 			if (!hsm?.awaitState) return;
-			hsm.awaitState((s) => s.startsWith("active.")).then(async () => {
-				const hasKnownPeers = await this.view?.document?.hasKnownPeers();
-				if (this.view?.document?.text || !hasKnownPeers) {
+			trackPromise(
+				`shareLink:awaitActive:${this.document.guid}`,
+				hsm.awaitState((s) => s.startsWith("active.")),
+			).then(async () => {
+				const hasKnownPeers = await this.document?.hasKnownPeers();
+				if (this.document?.text || !hasKnownPeers) {
 					this.updateFrontMatter();
 				}
 			});
 		}
 	}
 
+	private resolveDocument(): Document | undefined {
+		const file = getEditorFile(this.editor);
+		if (!file) return undefined;
+		const sharedFolders = getSharedFolders(this.editor);
+		if (!sharedFolders) return undefined;
+		const folder = sharedFolders.lookup(file.path);
+		if (!folder) return undefined;
+		return folder.proxy.getDoc(file.path);
+	}
+
 	updateFrontMatter() {
-		if (!(this.view instanceof LiveView)) {
+		if (!this.document) {
 			return;
 		}
-		if (!this.view || !this.view.shouldConnect) {
-			return;
-		}
-		if (this.view.document.localText != this.editor.state.doc.toString()) {
+		if (this.document.localText != this.editor.state.doc.toString()) {
 			return;
 		}
 		const text = this.editor.state.doc.toString();
-		const shareLink = `https://ydoc.live/${this.view.document.guid}`;
+		const shareLink = `https://ydoc.live/${this.document.guid}`;
 		const withShareLink = updateFrontMatter(text, {
 			shareLink: shareLink,
 		});
-		if (!(text || this.view.document.localText)) {
+		if (!(text || this.document.localText)) {
 			// document is empty
 			this.editor.dispatch({
 				changes: { from: 0, insert: withShareLink },

--- a/src/SharedFolder.ts
+++ b/src/SharedFolder.ts
@@ -65,6 +65,7 @@ import { generateHash } from "./hashing";
 import {
 	HSMStore,
 } from "./merge-hsm/persistence";
+import { trackPromise } from "./trackPromise";
 import * as Y from "yjs";
 
 export interface SharedFolderSettings {
@@ -169,6 +170,7 @@ export class SharedFolder extends HasProvider {
 	private unsubscribes: Unsubscriber[] = [];
 	private storageQuota?: number;
 	private pendingDeletes: Set<string> = new Set();
+	private inFlightRemaps: Set<string> = new Set();
 
 
 	private _persistence: IndexeddbPersistence;
@@ -179,6 +181,17 @@ export class SharedFolder extends HasProvider {
 	mergeManager: MergeManager;
 	private recordingBridge: E2ERecordingBridge;
 	private _pendingKeyframeUpdates: Map<string, Uint8Array[]> = new Map();
+	private onFolderYDocUpdate = (_update: Uint8Array, origin: unknown): void => {
+		// Folder metadata updates can arrive before SyncStore observers are active,
+		// or with origins that bypass SyncStore-level callbacks. Reconcile directly
+		// from Y.Doc updates so file materialization is not missed.
+		if (this.destroyed || origin === this) {
+			return;
+		}
+		trackPromise(`folder:ydocUpdateSync:${this.guid}`, this.syncFileTree()).catch(
+			(e) => this.error("syncFileTree on ydoc update failed", e),
+		);
+	};
 
 	constructor(
 		public appId: string,
@@ -240,6 +253,11 @@ export class SharedFolder extends HasProvider {
 		);
 		this.syncStore.on(async () => {
 			await this.syncFileTree();
+		});
+		const subscribedYdoc = this.ydoc;
+		subscribedYdoc.on("update", this.onFolderYDocUpdate);
+		this.unsubscribes.push(() => {
+			subscribedYdoc.off("update", this.onFolderYDocUpdate);
 		});
 
 		this.unsubscribes.push(
@@ -342,7 +360,17 @@ export class SharedFolder extends HasProvider {
 			onEffect: async (guid, effect) => {
 				this.debug?.(`[MergeManager] Effect for ${guid}:`, effect.type);
 				if (effect.type === "PERSIST_STATE") {
-					this._hsmStore.saveState(guid, effect.state);
+					// Keep reload gating aware of pending HSM state writes so
+					// plugin re-enable doesn't race persisted fork/LCA state.
+					const p = this._hsmStore
+						.saveState(guid, effect.state)
+						.catch((err) => {
+							this.error(
+								`[MergeManager] saveState failed for ${guid}:`,
+								err,
+							);
+						});
+					awaitOnReload(p);
 				} else if (effect.type === "SYNC_TO_REMOTE") {
 					// When a file is closed, ProviderIntegration is destroyed so no one
 					// listens for these effects. Handle them at the SharedFolder level.
@@ -387,25 +415,25 @@ export class SharedFolder extends HasProvider {
 		// Wire folder-level event subscriptions for idle mode remote updates
 		this.setupEventSubscriptions();
 
-		this.whenReady().then(async () => {
+		trackPromise(`folder:whenReady:${this.guid}`, this.whenReady()).then(async () => {
 			if (!this.destroyed) {
 				// Bulk-load LCA cache before registering HSMs
 				await this.mergeManager.initialize();
 
 				this.addLocalDocs();
 				this.syncFileTree();
-
-				// Transition all HSMs to idle mode since no editor is open yet.
-				// HSMs start in 'loading', then receive SET_MODE_IDLE from MergeManager.
-				if (this.mergeManager) {
-					const allGuids = Array.from(this.files.keys());
-					this.mergeManager.setActiveDocuments(new Set(), allGuids);
-				}
 			}
 		});
 
-		this.whenSynced().then(async () => {
+		trackPromise(`folder:whenSynced:${this.guid}`, this.whenSynced()).then(async () => {
 			this.syncStore.start();
+			// Remote folder metadata can land before SyncStore observers are installed.
+			// Replay local doc discovery and file-tree sync after start() so cloned
+			// folders do not miss their first batch of remote entries.
+			if (!this.destroyed) {
+				this.addLocalDocs();
+				await this.syncFileTree();
+			}
 			try {
 				this._persistence.set("path", this.path);
 				this._persistence.set("relay", this.relayId || "");
@@ -423,7 +451,7 @@ export class SharedFolder extends HasProvider {
 				if (isAuthoritative) {
 					await this.markSynced();
 				} else {
-					await this.onceProviderSynced();
+					await trackPromise(`folderSync:${this.guid}`, this.onceProviderSynced());
 					await this.markSynced();
 				}
 			} else if (!authoritative) {
@@ -431,7 +459,7 @@ export class SharedFolder extends HasProvider {
 				// provider to sync so _providerSynced is set. Without this,
 				// the folder's `synced` getter stays false and downstream
 				// flows (syncFileTree downloads) can fail.
-				await this.onceProviderSynced();
+				await trackPromise(`folderProviderSync:${this.guid}`, this.onceProviderSynced());
 			}
 		})();
 
@@ -447,6 +475,22 @@ export class SharedFolder extends HasProvider {
 				this.handleDocumentUpdateEvent(event);
 			},
 		);
+
+		// On (re)connect, the provider issues MSG_QUERY_SUBDOCS and receives
+		// the server's complete view of this folder's docs: guid → state
+		// vector. Seed tracked SVs from that one message and fire a full
+		// syncFileTree sweep; applyRemoteState + applyPendingUpload handle
+		// both inbound reconciliation and outbound pending-upload retry.
+		const provider = this._provider;
+		provider.onSubdocIndex = (serverIndex) => {
+			for (const [guid, svBytes] of Object.entries(serverIndex)) {
+				this.mergeManager?.seedTrackedRemoteSVFromBytes(guid, svBytes);
+			}
+			this.syncFileTree();
+		};
+		this.unsubscribes.push(() => {
+			provider.onSubdocIndex = null;
+		});
 	}
 
 	private handleDocumentUpdateEvent(event: EventMessage) {
@@ -957,8 +1001,8 @@ export class SharedFolder extends HasProvider {
 			if (awaitingUpdates) {
 				// If this is a brand new shared folder, we want to wait for a connection before we start reserving new guids for local files.
 				this.connect();
-				await this.onceConnected();
-				await this.onceProviderSynced();
+				await trackPromise(`folderConnected:${this.guid}`, this.onceConnected());
+				await trackPromise(`folderReady:${this.guid}`, this.onceProviderSynced());
 				return this;
 			}
 			// If this is a shared folder with edits, then we can behave as though we're just offline.
@@ -969,7 +1013,7 @@ export class SharedFolder extends HasProvider {
 			new Dependency<SharedFolder>(promiseFn, (): [boolean, SharedFolder] => {
 				return [this.ready, this];
 			});
-		return this.readyPromise.getPromise();
+		return trackPromise(`folder:whenReady:${this.guid}`, this.readyPromise.getPromise());
 	}
 
 	whenSynced(): Promise<void> {
@@ -996,7 +1040,7 @@ export class SharedFolder extends HasProvider {
 				}
 				return [this.persistenceSynced, undefined];
 			});
-		return this.whenSyncedPromise.getPromise();
+		return trackPromise(`folder:whenSynced:${this.guid}`, this.whenSyncedPromise.getPromise());
 	}
 
 	public get intent(): ConnectionIntent {
@@ -1074,6 +1118,76 @@ export class SharedFolder extends HasProvider {
 		}
 	}
 
+	/**
+	 * Swap a document's local CRDT identity from fromGuid to toGuid. Called
+	 * when the folder's meta CRDT resolves a path to a GUID that differs from
+	 * the one we enrolled locally (concurrent-create race, delete+recreate,
+	 * etc.). Tears down the losing Y.Doc + IDB + HSM state, downloads the
+	 * winning CRDT from the server, and creates a fresh Document under the
+	 * canonical GUID. HSMEditorPlugin picks up the Document swap on its next
+	 * CM6 update tick; the HSM's active.entering flow handles any content
+	 * divergence via its standard fork reconciliation path.
+	 *
+	 * Folder-level: does not require a living Document instance at fromGuid.
+	 * On failure, leaves pendingUpload intact so the next observer event or
+	 * startup scan re-detects and retries.
+	 */
+	private async executeRemap({ path, fromGuid, toGuid }: {
+		path: string;
+		fromGuid: string;
+		toGuid: string;
+	}): Promise<void> {
+		if (!this.connected) {
+			this.log(`[${path}] remap deferred: folder offline`);
+			return;
+		}
+
+		let updateBytes: Uint8Array | undefined;
+		try {
+			updateBytes = await this.backgroundSync.downloadByGuid(this, toGuid, path);
+		} catch (e) {
+			this.warn(`[${path}] remap download failed, deferring`, e);
+			return;
+		}
+
+		if (!updateBytes) {
+			this.log(`[${path}] remap deferred: server has guid but no content yet`);
+			return;
+		}
+
+		if (this.destroyed) {
+			this.log(`[${path}] remap aborted: folder destroyed during download`);
+			return;
+		}
+
+		const existingFile = this.files.get(fromGuid);
+		if (existingFile) {
+			this.files.delete(fromGuid);
+			this.fset.delete(existingFile);
+			existingFile.cleanup();
+			existingFile.destroy();
+		}
+
+		try {
+			indexedDB.deleteDatabase(`${this.appId}-relay-doc-${fromGuid}`);
+		} catch {}
+		const p = this._hsmStore.deleteState(fromGuid).catch(() => {});
+		awaitOnReload(p);
+
+		this.syncStore.pendingUpload.delete(path);
+
+		const newDoc = this.getOrCreateDoc(toGuid, path);
+		this.files.set(toGuid, newDoc);
+		this.fset.add(newDoc, true);
+
+		if (updateBytes) {
+			await newDoc.hsm?.initializeFromRemote(updateBytes);
+		}
+		await this.poll([toGuid]);
+
+		this.log(`Remapped Document ${path}: ${fromGuid} → ${toGuid}`);
+	}
+
 	private applyRemoteState(
 		guid: string,
 		path: string,
@@ -1100,13 +1214,14 @@ export class SharedFolder extends HasProvider {
 				return { op: "update", path, promise: file.pull() };
 			}
 
-			// Check for GUID mismatch - file exists but not mapped to remote GUID
+			// GUID mismatch — file at this path is mapped under a different
+			// guid locally than meta.id. Reconcile by swapping identity to
+			// the canonical meta.id.
 			if (!file) {
 				const localGuid = this.syncStore.get(path);
 				const localFile = localGuid ? this.files.get(localGuid) : null;
 
 				if (localGuid && localFile && isSyncFile(localFile) && isSyncFileMeta(meta)) {
-					// SyncFile with different GUID - check if content matches
 					const promise = this.remapIfHashMatches(
 						localFile,
 						localGuid,
@@ -1117,95 +1232,16 @@ export class SharedFolder extends HasProvider {
 					return { op: "update", path, promise };
 				}
 
-				if (localGuid && localFile && isDocument(localFile) && isDocumentMeta(meta)) {
-					// Document with different GUID — the local CRDT (under the
-					// old GUID) has independent history from the server's CRDT
-					// and cannot be merged. Download the server's content
-					// first (non-destructive), then destroy the old Document
-					// and create a fresh one under the server's GUID populated
-					// from the downloaded bytes. Disk stays untouched; if it
-					// differs from remote, poll() triggers DISK_CHANGED and
-					// the normal fork / fork-reconcile path pushes the diff
-					// upstream.
-					const promise = (async () => {
-						// Offline: defer. Next meta event retries on reconnect.
-						if (!this.connected) {
-							this.log(
-								`[${path}] remap deferred: folder offline`,
-							);
-							return;
-						}
-
-						// 1. Download remote CRDT first. Non-destructive — if
-						// this fails, old state is intact and the next meta
-						// event can retry.
-						let updateBytes: Uint8Array | undefined;
-						try {
-							updateBytes = await this.backgroundSync.downloadByGuid(
-								this,
-								guid,
-								path,
-							);
-						} catch (e) {
-							this.warn(
-								`[${path}] remap download failed, deferring`,
-								e,
-							);
-							return;
-						}
-
-						// SharedFolder may have been destroyed or the old
-						// doc removed during the await. Bail out — state has
-						// moved on without us. This also handles concurrent
-						// meta events racing into the same remap.
-						if (
-							this.destroyed ||
-							!this.files.has(localGuid)
-						) {
-							this.log(
-								`[${path}] remap aborted: state changed during download`,
-							);
-							return;
-						}
-
-						// 2. Tear down old Document.
-						this.files.delete(localGuid);
-						this.fset.delete(localFile);
-						localFile.cleanup();
-						localFile.destroy();
-
-						try {
-							indexedDB.deleteDatabase(
-								`${this.appId}-relay-doc-${localGuid}`,
-							);
-						} catch {}
-						const p = this._hsmStore
-							.deleteState(localGuid)
-							.catch(() => {});
-						awaitOnReload(p);
-
-						this.syncStore.pendingUpload.delete(path);
-
-						// 3. Create fresh Document under the server's GUID.
-						const newDoc = this.getOrCreateDoc(guid, path);
-						this.files.set(guid, newDoc);
-						this.fset.add(newDoc, true);
-
-						// 4. Enroll remote content (if any) and start the HSM.
-						// If the server has the guid but no content yet,
-						// `updateBytes` is undefined and the HSM starts with
-						// no LCA; provider sync will deliver content later.
-						if (updateBytes) {
-							await newDoc.hsm!.initializeFromRemote(updateBytes);
-						}
-						await this.poll([guid]);
-
-						this.log(
-							`Remapped Document ${path} from local GUID ${localGuid} to remote GUID ${guid}`,
-						);
-					})();
-
-					return { op: "update", path, promise };
+				if (localGuid && isDocumentMeta(meta)) {
+					return {
+						op: "update",
+						path,
+						promise: this.executeRemap({
+							path,
+							fromGuid: localGuid,
+							toGuid: guid,
+						}),
+					};
 				}
 			}
 
@@ -1327,15 +1363,73 @@ export class SharedFolder extends HasProvider {
 		ops: Operation[],
 		types: SyncType[],
 	) {
-		syncStore.forEach((meta, path) => {
+		syncStore.forEachWithPending((meta, path) => {
 			this._assertNamespacing(path);
-			if (types.contains(meta.type)) {
-				this._assertNamespacing(path);
+			if (meta && types.contains(meta.type)) {
 				ops.push(
 					this.applyRemoteState(meta.id, path, syncStore.remoteIds, diffLog),
 				);
+			} else if (!meta && types.contains(SyncType.Document)) {
+				// Pending upload only — no meta yet. Retry the upload so
+				// syncFileTree's sweep covers outbound reconciliation alongside
+				// the inbound remap/update work above.
+				ops.push(this.applyPendingUpload(path));
 			}
 		});
+	}
+
+	/**
+	 * Retry a pending upload for a path whose local meta was never written
+	 * (the initial enqueueSync failed or was deferred). Resolves the file via
+	 * pendingUpload's guid, re-enqueues sync, and calls markUploaded on success
+	 * so the local meta gets written and pendingUpload is cleared.
+	 */
+	private applyPendingUpload(path: string): OperationType {
+		const pendingGuid = this.syncStore.pendingUpload.get(path);
+		if (!pendingGuid) {
+			return { op: "noop", path, promise: Promise.resolve() };
+		}
+
+		// Server-authoritative rule: if committed filemeta already points at a
+		// different GUID for this path, do not publish/overwrite local pending
+		// metadata. Adopt the committed GUID instead.
+		const committedMeta = this.syncStore.getCommittedMeta(path);
+		if (committedMeta && committedMeta.id !== pendingGuid) {
+			this.warn(
+				"[applyPendingUpload] committed GUID differs from pending upload",
+				{
+					path,
+					pendingGuid,
+					committedGuid: committedMeta.id,
+				},
+			);
+			const pendingFile = this.files.get(pendingGuid);
+			if (isDocumentMeta(committedMeta) && pendingFile && isDocument(pendingFile)) {
+				return {
+					op: "update",
+					path,
+					promise: this.executeRemap({
+						path,
+						fromGuid: pendingGuid,
+						toGuid: committedMeta.id,
+					}),
+				};
+			}
+			return { op: "noop", path, promise: Promise.resolve() };
+		}
+
+		const file = this.files.get(pendingGuid);
+		if (!file || !(isDocument(file) || isCanvas(file) || isSyncFile(file))) {
+			return { op: "noop", path, promise: Promise.resolve() };
+		}
+		return {
+			op: "update",
+			path,
+			promise: (async () => {
+				await this.backgroundSync.enqueueSync(file);
+				await this.markUploaded(file);
+			})(),
+		};
 	}
 
 	syncFileTree(): Promise<void> {
@@ -1405,7 +1499,7 @@ export class SharedFolder extends HasProvider {
 
 		this.syncFileTreePromise = new SharedPromise<void>(promiseFn);
 
-		return this.syncFileTreePromise.getPromise();
+		return trackPromise(`folder:syncFileTree:${this.guid}`, this.syncFileTreePromise.getPromise());
 	}
 
 	move(path: string) {
@@ -1548,6 +1642,22 @@ export class SharedFolder extends HasProvider {
 			if (!this.syncStore) {
 				return;
 			}
+
+			// Server-authoritative rule: never overwrite an existing committed
+			// GUID for this path with a local pending GUID.
+			const committedMeta = this.syncStore.getCommittedMeta(file.path);
+			if (committedMeta && committedMeta.id !== meta.id) {
+				this.warn(
+					"[markUploaded] committed GUID differs from local upload metadata",
+					{
+						path: file.path,
+						localGuid: meta.id,
+						committedGuid: committedMeta.id,
+					},
+				);
+				return;
+			}
+
 			if (this.syncStore.willSet(file.path, meta)) {
 				this.log("new meta", file.path, meta);
 				this.ydoc.transact(() => {
@@ -1727,7 +1837,7 @@ export class SharedFolder extends HasProvider {
 				canvas.markOrigin("local");
 				this.log(`[${canvas.path}] Uploading file`);
 				await this.backgroundSync.enqueueSync(canvas);
-				this.markUploaded(canvas);
+				await this.markUploaded(canvas);
 			}
 		})();
 
@@ -1750,12 +1860,13 @@ export class SharedFolder extends HasProvider {
 		const canvas = this.getOrCreateCanvas(guid, vpath);
 
 		(async () => {
-			this.whenReady().then(async () => {
+			trackPromise(`folder:canvasReady:${canvas.guid}`, this.whenReady()).then(async () => {
 				const synced = await canvas.getServerSynced();
 				if (canvas.stat.size === 0 && !synced) {
 					this.backgroundSync.enqueueCanvasDownload(canvas);
 				} else if (this.pendingUpload.get(canvas.path)) {
-					this.backgroundSync.enqueueSync(canvas);
+					await this.backgroundSync.enqueueSync(canvas);
+					await this.markUploaded(canvas);
 				}
 			});
 		})();
@@ -1807,10 +1918,6 @@ export class SharedFolder extends HasProvider {
 			throw new Error("unexpected ifile type");
 		}
 		doc.move(vpath, this);
-
-		// Document creates its own HSM via ensureHSM() - no need to register separately.
-		// Just ensure the HSM exists after the move.
-		doc.ensureHSM();
 
 		if (this._localOnly && doc.hsm) {
 			doc.hsm.setLocalOnly(true);
@@ -1877,7 +1984,7 @@ export class SharedFolder extends HasProvider {
 				// disk if not already enrolled, and sets origin atomically.
 				await doc.hsm?.initializeWithContent();
 				await this.backgroundSync.enqueueSync(doc);
-				this.markUploaded(doc);
+				await this.markUploaded(doc);
 			}
 		})();
 
@@ -1900,12 +2007,13 @@ export class SharedFolder extends HasProvider {
 		const doc = this.getOrCreateDoc(guid, vpath);
 
 		(async () => {
-			this.whenReady().then(async () => {
+			trackPromise(`folder:docReady:${doc.guid}`, this.whenReady()).then(async () => {
 				const synced = await doc.getServerSynced();
 				if (doc.tfile?.stat.size === 0 && !synced) {
 					this.backgroundSync.enqueueDownload(doc, !flags().enableNewSyncStatus);
 				} else if (this.pendingUpload.get(doc.path)) {
-					this.backgroundSync.enqueueSync(doc);
+					await this.backgroundSync.enqueueSync(doc);
+					await this.markUploaded(doc);
 				}
 			});
 		})();
@@ -2028,7 +2136,11 @@ export class SharedFolder extends HasProvider {
 		}
 		const file = this.getOrCreateSyncFile(guid, vpath, tfile);
 
-		this.backgroundSync.enqueueSync(file);
+		void (async () => {
+			if (!this.pendingUpload.get(file.path)) return;
+			await this.backgroundSync.enqueueSync(file);
+			await this.markUploaded(file);
+		})();
 
 		this.fset.add(file, update);
 		return file;
@@ -2097,6 +2209,10 @@ export class SharedFolder extends HasProvider {
 
 	isPendingDelete(vpath: string): boolean {
 		return this.pendingDeletes.has(vpath);
+	}
+
+	isPendingUpload(vpath: string): boolean {
+		return this.pendingUpload.has(vpath);
 	}
 
 	deleteFile(vpath: string) {

--- a/src/SharedFolder.ts
+++ b/src/SharedFolder.ts
@@ -360,7 +360,7 @@ export class SharedFolder extends HasProvider {
 					s3rn: s3rn ? S3RN.encode(s3rn) : "",
 				};
 			},
-			userId: loginManager?.user?.id,
+			userId: flags().enablePermanentUserData ? loginManager?.user?.id : undefined,
 			yaml: { parse: parseYaml, stringify: stringifyYaml },
 		});
 

--- a/src/SharedFolder.ts
+++ b/src/SharedFolder.ts
@@ -2224,6 +2224,7 @@ export class SharedFolder extends HasProvider {
 		this.unsubscribes.forEach((unsub) => {
 			unsub();
 		});
+		this.unsubscribes = [];
 
 		this.files.forEach((doc: IFile) => {
 			doc.destroy();
@@ -2231,6 +2232,7 @@ export class SharedFolder extends HasProvider {
 		});
 
 		this.recordingBridge?.dispose();
+		this.cas.destroy();
 		this.syncStore.destroy();
 		this.syncSettingsManager.destroy();
 		this.mergeManager?.destroy();
@@ -2256,6 +2258,7 @@ export class SharedFolder extends HasProvider {
 		this.loginManager = null as any;
 		this.tokenStore = null as any;
 		this.fileManager = null as any;
+		this.cas = null as any;
 		this.syncStore = null as any;
 		this.syncSettingsManager = null as any;
 		this.mergeManager = null as any;

--- a/src/SyncStore.ts
+++ b/src/SyncStore.ts
@@ -125,6 +125,32 @@ export class SyncStore extends Observable<SyncStore> {
 		});
 	}
 
+	/**
+	 * Like forEach, but also yields pending-upload-only paths (where no meta
+	 * has been written yet). The callback receives `null` for those entries.
+	 * Used by reconciliation sweeps that need to retry uploads which never
+	 * completed (and thus never wrote meta locally).
+	 */
+	forEachWithPending(
+		callbackFn: (meta: Meta | null, path: string) => void,
+	) {
+		const seen = new Set<string>();
+		this.meta.forEach((meta, path) => {
+			if (this.deleteSet.has(path)) return;
+			seen.add(path);
+			callbackFn(meta, path);
+		});
+		this.overlay.forEach((meta, path) => {
+			if (seen.has(path) || this.deleteSet.has(path)) return;
+			seen.add(path);
+			callbackFn(meta, path);
+		});
+		this.pendingUpload.forEach((_guid, path) => {
+			if (seen.has(path) || this.deleteSet.has(path)) return;
+			callbackFn(null, path);
+		});
+	}
+
 	has(path: string) {
 		if (this.renames.has(path)) {
 			path = this.renames.get(path)!;
@@ -182,10 +208,7 @@ export class SyncStore extends Observable<SyncStore> {
 		this.log("metadata write (path, existing, meta)", vpath, existing, meta);
 		this.meta.set(vpath, meta);
 		const pendingGuid = this.pendingUpload.get(vpath);
-		if (
-			pendingGuid &&
-			pendingGuid === meta.id
-		) {
+		if (pendingGuid && pendingGuid === meta.id) {
 			this.pendingUpload.delete(vpath);
 		}
 	}
@@ -342,6 +365,21 @@ export class SyncStore extends Observable<SyncStore> {
 			return undefined;
 		}
 		return meta;
+	}
+
+	/**
+	 * Get committed file metadata from the shared Y.Map only.
+	 * Does not include pending uploads, overlay migration entries, or legacy ids.
+	 */
+	getCommittedMeta(vpath: string): Meta | undefined {
+		this.assertVPath(vpath);
+		if (this.renames.has(vpath)) {
+			vpath = this.renames.get(vpath)!;
+		}
+		if (this.deleteSet.has(vpath)) {
+			return undefined;
+		}
+		return this.meta.get(vpath);
 	}
 
 	delete(vpath: string) {

--- a/src/TextViewPlugin.ts
+++ b/src/TextViewPlugin.ts
@@ -7,6 +7,7 @@ import { ViewHookPlugin } from "./plugins/ViewHookPlugin";
 import { isLive, type LiveView } from "./LiveViews";
 import { YText, YTextEvent, Transaction } from "yjs/dist/src/internals";
 import { diffMatchPatch } from "./y-diffMatchPatch";
+import { trackPromise } from "./trackPromise";
 
 export class TextFileViewPlugin extends HasLogging {
 	view: LiveView<TextFileView>;
@@ -33,14 +34,21 @@ export class TextFileViewPlugin extends HasLogging {
 				file.path,
 			);
 			if (folder) {
-				const newDoc = folder.proxy.getDoc(file.path);
-				this.warn("[TextViewPlugin] getDocument() found:", {
-					newDocPath: newDoc.path,
-					newDocGuid: newDoc.guid,
-					newDocTFile: newDoc._tfile?.path,
-				});
-				this.doc = newDoc;
-				return this.doc;
+				try {
+					const newDoc = folder.proxy.getDoc(file.path);
+					this.warn("[TextViewPlugin] getDocument() found:", {
+						newDocPath: newDoc.path,
+						newDocGuid: newDoc.guid,
+						newDocTFile: newDoc._tfile?.path,
+					});
+					this.doc = newDoc;
+					return this.doc;
+				} catch (error) {
+					this.warn("[TextViewPlugin] getDocument() failed:", {
+						filePath: file.path,
+						error: error instanceof Error ? error.message : String(error),
+					});
+				}
 			}
 		}
 		// Fallback to the LiveView's document
@@ -106,7 +114,7 @@ export class TextFileViewPlugin extends HasLogging {
 
 			const hsm = this.doc.hsm;
 			if (hsm?.awaitState) {
-				await hsm.awaitState((s) => s.startsWith("active."));
+				await trackPromise(`textView:awaitActive:${this.doc?.guid}`, hsm.awaitState((s) => s.startsWith("active.")));
 			} else {
 				return;
 			}

--- a/src/UpdateManager.ts
+++ b/src/UpdateManager.ts
@@ -83,6 +83,7 @@ export class UpdateManager extends Observable<UpdateManager> {
 	private lastReleaseCheck: number = 0;
 	private lastChannelCheck: number = 0;
 	private readonly CHECK_INTERVAL = 1000 * 60 * 60 * 24;
+	private updateGeneration: number = 0;
 	observableName = "UpdateManager";
 
 	constructor(
@@ -96,6 +97,9 @@ export class UpdateManager extends Observable<UpdateManager> {
 	}
 
 	public get releases(): Release[] {
+		if (this.destroyed) {
+			return [];
+		}
 		return [...this.githubReleases.values()].sort((a, b) =>
 			b.tag_name.localeCompare(a.tag_name, undefined, {
 				numeric: true,
@@ -105,11 +109,21 @@ export class UpdateManager extends Observable<UpdateManager> {
 	}
 
 	public get beta(): Release | undefined {
+		if (this.destroyed) {
+			return undefined;
+		}
 		return this.releaseChannels.get("beta");
 	}
 
 	public get stable(): Release | undefined {
+		if (this.destroyed) {
+			return undefined;
+		}
 		return this.releaseChannels.get("stable");
+	}
+
+	private isActiveGeneration(generation: number): boolean {
+		return !this.destroyed && generation === this.updateGeneration;
 	}
 
 	private async fetchReleases(): Promise<Release[]> {
@@ -161,6 +175,9 @@ export class UpdateManager extends Observable<UpdateManager> {
 	public async fetchLatestTagFromChannel(
 		channel: "beta" | "stable",
 	): Promise<string | null> {
+		if (this.destroyed) {
+			return null;
+		}
 		try {
 			const manifestPath = {
 				beta: "manifest-beta.json",
@@ -182,6 +199,10 @@ export class UpdateManager extends Observable<UpdateManager> {
 	}
 
 	public async getReleases(): Promise<Release[]> {
+		const generation = this.updateGeneration;
+		if (!this.isActiveGeneration(generation)) {
+			return [];
+		}
 		try {
 			// Only fetch if we haven't fetched in a while to avoid rate limiting
 			const now = Date.now();
@@ -197,6 +218,9 @@ export class UpdateManager extends Observable<UpdateManager> {
 			this.lastReleaseCheck = now;
 
 			const releases = await this.fetchReleases();
+			if (!this.isActiveGeneration(generation)) {
+				return [];
+			}
 			const localReleases = new Set<string>([...this.githubReleases.keys()]);
 			const remoteReleases = new Set<string>();
 			releases.forEach((release: Release) => {
@@ -212,6 +236,9 @@ export class UpdateManager extends Observable<UpdateManager> {
 			});
 
 			const latest = await this.fetchLatestRelease();
+			if (!this.isActiveGeneration(generation)) {
+				return [];
+			}
 			if (latest) {
 				latest.latest = true;
 				this.githubReleases.set(latest.tag_name, latest);
@@ -220,12 +247,21 @@ export class UpdateManager extends Observable<UpdateManager> {
 			// Notify subscribers that we have new releases data
 			this.notifyListeners();
 		} catch (error) {
-			this.error("Failed to fetch GitHub releases:", error);
+			if (this.isActiveGeneration(generation)) {
+				this.error("Failed to fetch GitHub releases:", error);
+			}
+		}
+		if (!this.isActiveGeneration(generation)) {
+			return [];
 		}
 		return [...this.githubReleases.values()];
 	}
 
 	private async getChannelRelease(): Promise<Release | null> {
+		const generation = this.updateGeneration;
+		if (!this.isActiveGeneration(generation)) {
+			return null;
+		}
 		const now = Date.now();
 		const channelRelease = this.releaseChannels.get(
 			this.releaseSettings.get().channel,
@@ -236,6 +272,9 @@ export class UpdateManager extends Observable<UpdateManager> {
 		this.lastReleaseCheck = now;
 
 		const releases = await this.getReleases();
+		if (!this.isActiveGeneration(generation)) {
+			return null;
+		}
 		if (releases.length === 0) {
 			this.debug("No releases found");
 			return null;
@@ -245,6 +284,9 @@ export class UpdateManager extends Observable<UpdateManager> {
 		if (!channel) return null;
 
 		const version = await this.fetchLatestTagFromChannel(channel);
+		if (!this.isActiveGeneration(generation)) {
+			return null;
+		}
 		if (!version) return null;
 
 		const release = releases.find((release) => {
@@ -259,14 +301,22 @@ export class UpdateManager extends Observable<UpdateManager> {
 	}
 
 	private async update() {
+		const generation = this.updateGeneration;
 		await this.getReleases();
+		if (!this.isActiveGeneration(generation)) {
+			return;
+		}
 		await this.getChannelRelease();
 	}
 
 	public start(): void {
-		this.update();
+		if (this.destroyed) {
+			return;
+		}
+		this.updateGeneration += 1;
+		void this.update();
 		this.updateCheckInterval = this.timeProvider.setInterval(
-			() => this.update(),
+			() => void this.update(),
 			this.CHECK_INTERVAL,
 		);
 	}
@@ -384,8 +434,12 @@ export class UpdateManager extends Observable<UpdateManager> {
 	}
 
 	override destroy(): void {
+		if (this.destroyed) {
+			return;
+		}
 		// Stop periodic update checking
 		this.stop();
+		this.updateGeneration += 1;
 
 		// Set state to null before destroying
 		this.githubReleases = null as any;

--- a/src/client/provider.ts
+++ b/src/client/provider.ts
@@ -183,6 +183,7 @@ const setupWS = (provider: YSweetProvider) => {
 		provider.ws = websocket;
 		provider.wsconnecting = true;
 		provider.wsconnected = false;
+		provider.wsConnectStartTime = time.getUnixTime();
 		provider.synced = false;
 
 		websocket.onmessage = (event) => {
@@ -199,6 +200,7 @@ const setupWS = (provider: YSweetProvider) => {
 			provider.emit("connection-close", [event, provider]);
 			provider.ws = null;
 			provider.wsconnecting = false;
+			provider.wsConnectStartTime = 0;
 			if (provider.wsconnected) {
 				provider.wsconnected = false;
 				provider.synced = false;
@@ -236,6 +238,7 @@ const setupWS = (provider: YSweetProvider) => {
 			provider.wsLastMessageReceived = time.getUnixTime();
 			provider.wsconnecting = false;
 			provider.wsconnected = true;
+			provider.wsConnectStartTime = 0;
 			provider.wsUnsuccessfulReconnects = 0;
 			provider.emit("status", [
 				{
@@ -385,6 +388,7 @@ export class YSweetProvider extends Observable<string> {
 	_synced: boolean;
 	ws: WebSocket | null;
 	wsLastMessageReceived: number;
+	wsConnectStartTime: number;
 	shouldConnect: boolean;
 	_resyncInterval: ReturnType<typeof setInterval> | number; // TODO: is setting this to 0 used as null?
 	_bcSubscriber: (...args: any[]) => any;
@@ -457,6 +461,7 @@ export class YSweetProvider extends Observable<string> {
 		this._synced = false;
 		this.ws = null;
 		this.wsLastMessageReceived = 0;
+		this.wsConnectStartTime = 0;
 		this.shouldConnect = connect;
 		this.maxConnectionErrors = maxConnectionErrors;
 		this.eventSubscriptions = new Set();
@@ -546,6 +551,17 @@ export class YSweetProvider extends Observable<string> {
 			) {
 				// no message received in a long time - not even your own awareness
 				// updates (which are updated every 15 seconds)
+				this.ws?.close();
+			}
+			if (
+				this.wsconnecting &&
+				this.ws?.readyState === WebSocket.CONNECTING &&
+				this.wsConnectStartTime > 0 &&
+				messageReconnectTimeout <
+					time.getUnixTime() - this.wsConnectStartTime
+			) {
+				// Connection attempt is stuck in CONNECTING with no transition.
+				// Force-close so onclose can run backoff/retry logic.
 				this.ws?.close();
 			}
 		}, messageReconnectTimeout / 10);
@@ -712,6 +728,8 @@ export class YSweetProvider extends Observable<string> {
 	disconnect() {
 		this.shouldConnect = false;
 		this.wsconnected = false;
+		this.wsconnecting = false;
+		this.wsConnectStartTime = 0;
 		this.disconnectBc();
 		if (this.ws !== null) {
 			this.ws.close();
@@ -723,6 +741,10 @@ export class YSweetProvider extends Observable<string> {
 	connect() {
 		this.shouldConnect = true;
 		if (!this.wsconnected && this.ws === null) {
+			// Explicit connect requests should start a fresh retry budget.
+			// Without this, a previous exhausted reconnect cycle can leave the
+			// provider permanently offline until the plugin is recreated.
+			this.wsUnsuccessfulReconnects = 0;
 			setupWS(this);
 			this.connectBc();
 		}
@@ -864,4 +886,3 @@ export class YSweetProvider extends Observable<string> {
 	}
 
 }
-

--- a/src/components/FeatureFlagModalContent.svelte
+++ b/src/components/FeatureFlagModalContent.svelte
@@ -27,56 +27,64 @@
 
 <div class="feature-flag-toggle-modal">
 	<h2>Feature Flags</h2>
-	{#each Object.entries(settings)
-		.filter(([k, v]) => isKeyOfFeatureFlags(k))
-		.sort() as [flagName, value]}
-		<div class="feature-flag-item setting-item">
-			<div class="setting-item-info">
-				<div class="setting-item-name">{flagName}</div>
-				<div class="setting-item-description">Toggle {flagName} on or off</div>
-			</div>
-			<div class="setting-item-control">
-				<div
-					role="checkbox"
-					aria-checked={value}
-					tabindex="0"
-					on:keypress={() => {
-						if (!isKeyOfFeatureFlags(flagName))
-							throw new Error("Unexpected feature flag!");
-						toggleFlag(flagName);
-					}}
-					class="checkbox-container"
-					class:is-enabled={value}
-					on:click={() => {
-						if (!isKeyOfFeatureFlags(flagName))
-							throw new Error("Unexpected feature flag!");
-						toggleFlag(flagName);
-					}}
-				>
-					<input type="checkbox" tabindex="-1" checked={value} />
-					<div class="checkbox-toggle"></div>
+	<div class="feature-flag-list">
+		{#each Object.entries(settings)
+			.filter(([k, v]) => isKeyOfFeatureFlags(k))
+			.sort() as [flagName, value]}
+			<div class="feature-flag-item setting-item">
+				<div class="setting-item-info">
+					<div class="setting-item-name">{flagName}</div>
+					<div class="setting-item-description">Toggle {flagName} on or off</div>
+				</div>
+				<div class="setting-item-control">
+					<div
+						role="checkbox"
+						aria-checked={value}
+						tabindex="0"
+						on:keypress={() => {
+							if (!isKeyOfFeatureFlags(flagName))
+								throw new Error("Unexpected feature flag!");
+							toggleFlag(flagName);
+						}}
+						class="checkbox-container"
+						class:is-enabled={value}
+						on:click={() => {
+							if (!isKeyOfFeatureFlags(flagName))
+								throw new Error("Unexpected feature flag!");
+							toggleFlag(flagName);
+						}}
+					>
+						<input type="checkbox" tabindex="-1" checked={value} />
+						<div class="checkbox-toggle"></div>
+					</div>
 				</div>
 			</div>
-		</div>
-	{/each}
+		{/each}
+	</div>
 
-	<div class="setting-item">
-		<div class="setting-item-control">
-			<button
-				aria-label="apply flag settings"
-				on:click={reload}
-				on:keypress={reload}
-				tabindex="0"
-			>
-				Apply
-			</button>
-		</div>
+	<div class="feature-flag-footer">
+		<button
+			aria-label="apply flag settings"
+			on:click={reload}
+			on:keypress={reload}
+			tabindex="0"
+		>
+			Apply
+		</button>
 	</div>
 </div>
 
 <style>
 	.feature-flag-toggle-modal {
 		padding: 1rem;
+		display: flex;
+		flex-direction: column;
+		max-height: 70vh;
+	}
+	.feature-flag-list {
+		overflow-y: auto;
+		flex: 1;
+		min-height: 0;
 	}
 	.feature-flag-item {
 		display: flex;
@@ -84,6 +92,13 @@
 		align-items: center;
 		padding: 0.5rem 0;
 		border-top: 1px solid var(--background-modifier-border);
+	}
+	.feature-flag-footer {
+		padding-top: 1rem;
+		border-top: 1px solid var(--background-modifier-border);
+		display: flex;
+		justify-content: flex-end;
+		flex-shrink: 0;
 	}
 	.checkbox-container {
 		cursor: pointer;

--- a/src/editorContext.ts
+++ b/src/editorContext.ts
@@ -1,0 +1,41 @@
+import { EditorView } from "@codemirror/view";
+import {
+	editorInfoField,
+	type App,
+	type CachedMetadata,
+	type TFile,
+} from "obsidian";
+import type Live from "./main";
+import type { SharedFolders } from "./SharedFolder";
+
+type AppWithPluginRegistry = App & {
+	plugins?: {
+		plugins?: Record<string, unknown>;
+	};
+};
+
+export interface MetadataBridge {
+	onMeta(tfile: TFile, cb: (data: string, cache: CachedMetadata) => void): void;
+	offMeta(tfile: TFile): void;
+}
+
+function getEditorInfo(editor: EditorView): any | null {
+	return editor.state.field(editorInfoField, false) ?? null;
+}
+
+export function getApp(editor: EditorView): App | null {
+	return (getEditorInfo(editor)?.app as App | undefined) ?? null;
+}
+
+export function getRelayPlugin(editor: EditorView): Live | null {
+	const app = getApp(editor) as AppWithPluginRegistry | null;
+	return (app?.plugins?.plugins?.["system3-relay"] as Live | undefined) ?? null;
+}
+
+export function getEditorFile(editor: EditorView): TFile | null {
+	return (getEditorInfo(editor)?.file as TFile | undefined) ?? null;
+}
+
+export function getSharedFolders(editor: EditorView): SharedFolders | null {
+	return getRelayPlugin(editor)?.sharedFolders ?? null;
+}

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -20,6 +20,7 @@ export interface FeatureFlags {
 	enableDraftMode: boolean;
 	enableNewSyncStatus: boolean;
 	enableResourceMeter: boolean;
+	enablePermanentUserData: boolean;
 }
 
 export const FeatureFlagDefaults: FeatureFlags = {
@@ -44,6 +45,7 @@ export const FeatureFlagDefaults: FeatureFlags = {
 	enableDraftMode: false,
 	enableNewSyncStatus: false,
 	enableResourceMeter: false,
+	enablePermanentUserData: true,
 } as const;
 
 export function isKeyOfFeatureFlags(key: string): key is keyof FeatureFlags {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1372,105 +1372,187 @@ export default class Live extends Plugin {
 	}
 
 	onunload() {
+		const teardownStep = (name: string, fn: () => void) => {
+			this.debug(`[onunload] ${name}`);
+			try {
+				fn();
+			} catch (error) {
+				console.error(`[Relay] onunload failed at step: ${name}`, error);
+				throw error;
+			}
+		};
 		setActiveTracker(null);
 		this.promises.destroy();
 		this.promises = null as any;
 		// Clean up debug API globals
-		this.relayDebugAPI?.destroy();
+		teardownStep("relayDebugAPI.destroy", () => {
+			this.relayDebugAPI?.destroy();
+		});
 		this.relayDebugAPI = null as any;
 
 		// Cleanup all monkeypatches and destroy the singleton
-		Patcher.destroy();
+		teardownStep("Patcher.destroy", () => {
+			Patcher.destroy();
+		});
 
-		this.timeProvider?.destroy();
+		teardownStep("timeProvider.destroy", () => {
+			this.timeProvider?.destroy();
+		});
+		this.timeProvider = null as any;
 
-		this.folderNavDecorations?.destroy();
+		teardownStep("folderNavDecorations.destroy", () => {
+			this.folderNavDecorations?.destroy();
+		});
+		this.folderNavDecorations = null as any;
 
-		this.resourceMeter?.destroy();
+		teardownStep("resourceMeter.destroy", () => {
+			this.resourceMeter?.destroy();
+		});
 		this.resourceMeter = null;
 
-		this.app.workspace.detachLeavesOfType(VIEW_TYPE_DIFFERENCES);
+		teardownStep("detachLeavesOfType", () => {
+			this.app.workspace.detachLeavesOfType(VIEW_TYPE_DIFFERENCES);
+		});
 
 		// Explicitly destroy the update manager
 		if (this.updateManager) {
-			this.updateManager.destroy();
+			teardownStep("updateManager.destroy", () => {
+				this.updateManager.destroy();
+			});
 			this.updateManager = null as any;
 		}
 
-		this._liveViews?.destroy();
+		teardownStep("liveViews.destroy", () => {
+			this._liveViews?.destroy();
+		});
 		this._liveViews = null as any;
 
-		this.relayManager?.destroy();
+		teardownStep("relayManager.destroy", () => {
+			this.relayManager?.destroy();
+		});
 		this.relayManager = null as any;
 
-		this.deviceManager?.destroy();
+		teardownStep("deviceManager.destroy", () => {
+			this.deviceManager?.destroy();
+		});
 		this.deviceManager = null as any;
 
-		this.tokenStore?.stop();
-		this.tokenStore?.clearState();
-		this.tokenStore?.destroy();
+		teardownStep("tokenStore.stop", () => {
+			this.tokenStore?.stop();
+		});
+		teardownStep("tokenStore.clearState", () => {
+			this.tokenStore?.clearState();
+		});
+		teardownStep("tokenStore.destroy", () => {
+			this.tokenStore?.destroy();
+		});
 		this.tokenStore = null as any;
 
-		this.networkStatus?.stop();
-		this.networkStatus?.destroy();
+		teardownStep("networkStatus.stop", () => {
+			this.networkStatus?.stop();
+		});
+		teardownStep("networkStatus.destroy", () => {
+			this.networkStatus?.destroy();
+		});
 		this.networkStatus = null as any;
 
-		this.openModals.forEach((modal) => {
-			modal.close();
+		teardownStep("openModals.close", () => {
+			this.openModals.forEach((modal) => {
+				modal.close();
+			});
 		});
 		this.openModals.length = 0;
 
-		this.sharedFolders?.destroy();
+		teardownStep("sharedFolders.destroy", () => {
+			this.sharedFolders?.destroy();
+		});
 		this.sharedFolders = null as any;
 
 		// Flush pending HSM writes and close the database after SharedFolders
 		// are destroyed (no more writes will be queued).
-		awaitOnReload(this._hsmStore?.destroy(), `plugin:teardown:hsmStore.destroy:${this._instanceId}`);
+		teardownStep("hsmStore.destroy", () => {
+			awaitOnReload(this._hsmStore?.destroy(), `plugin:teardown:hsmStore.destroy:${this._instanceId}`);
+		});
 		this._hsmStore = null as any;
 
-		this.settingsTab?.destroy();
+		teardownStep("settingsTab.destroy", () => {
+			this.settingsTab?.destroy();
+		});
 		this.settingsTab = null as any;
 
-		this.loginManager?.destroy();
+		teardownStep("loginManager.destroy", () => {
+			this.loginManager?.destroy();
+		});
 		this.loginManager = null as any;
 
-		this.backgroundSync?.destroy();
+		teardownStep("backgroundSync.destroy", () => {
+			this.backgroundSync?.destroy();
+		});
 		this.backgroundSync = null as any;
 
-		this.hashStore.destroy();
+		teardownStep("hashStore.destroy", () => {
+			this.hashStore.destroy();
+		});
 		this.hashStore = null as any;
 
-		this.app?.workspace.updateOptions();
+		teardownStep("workspace.updateOptions", () => {
+			this.app?.workspace.updateOptions();
+		});
 		(this.app as any).reloadRelay = undefined;
 		this.app = null as any;
 		this.fileManager = null as any;
 		this.manifest = null as any;
 		this.vault = null as any;
 
-		this.debugSettings.destroy();
+		teardownStep("debugSettings.destroy", () => {
+			this.debugSettings.destroy();
+		});
 		this.debugSettings = null as any;
-		this.folderSettings.destroy();
+		teardownStep("folderSettings.destroy", () => {
+			this.folderSettings.destroy();
+		});
 		this.folderSettings = null as any;
 
 		// Destroy FeatureFlagManager before destroying featureSettings
-		FeatureFlagManager.destroy();
+		teardownStep("FeatureFlagManager.destroy", () => {
+			FeatureFlagManager.destroy();
+		});
 
-		this.featureSettings.destroy();
+		teardownStep("featureSettings.destroy", () => {
+			this.featureSettings.destroy();
+		});
 		this.featureSettings = null as any;
-		this.releaseSettings.destroy();
+		teardownStep("releaseSettings.destroy", () => {
+			this.releaseSettings.destroy();
+		});
 		this.releaseSettings = null as any;
-		this.loginSettings.destroy();
+		teardownStep("loginSettings.destroy", () => {
+			this.loginSettings.destroy();
+		});
 		this.loginSettings = null as any;
-		this.endpointSettings.destroy();
+		teardownStep("endpointSettings.destroy", () => {
+			this.endpointSettings.destroy();
+		});
 		this.endpointSettings = null as any;
+		teardownStep("settings.destroy", () => {
+			this.settings.destroy();
+		});
+		this.settings = null as any;
 
 		this.interceptedUrls.length = 0;
-		PostOffice.destroy();
+		teardownStep("PostOffice.destroy", () => {
+			PostOffice.destroy();
+		});
 
 		this.notifier = null as any;
 
-		auditTeardown();
-		flushLogs();
+		teardownStep("auditTeardown", () => {
+			auditTeardown();
+		});
+		teardownStep("flushLogs", () => {
+			flushLogs();
+		});
+		this.promises = null as any;
 
 		// Clear our instance ID from the leak-detection set LAST — if
 		// anything above throws, we leave the ID in place so the next

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,6 +17,7 @@ import { Platform } from "obsidian";
 import { relative } from "path-browserify";
 import { SharedFolder } from "./SharedFolder";
 import type { SharedFolderSettings } from "./SharedFolder";
+import type { MetadataBridge } from "./editorContext";
 import { S3RN } from "./S3RN";
 import { LiveViewManager } from "./LiveViews";
 
@@ -140,6 +141,9 @@ export default class Live extends Plugin {
 	warn!: (...args: unknown[]) => void;
 	error!: (...args: unknown[]) => void;
 	private _liveViews!: LiveViewManager;
+	get metadataBridge(): MetadataBridge | undefined {
+		return this._liveViews;
+	}
 	fileDiffMergeWarningKey = "file-diff-merge-warning";
 	version = GIT_TAG;
 	repo = REPOSITORY;

--- a/src/markdownView/InvalidLinkExtension.ts
+++ b/src/markdownView/InvalidLinkExtension.ts
@@ -7,14 +7,17 @@ import {
 	type DecorationSet,
 } from "@codemirror/view";
 import { WidgetType } from "@codemirror/view";
-import { TextFileView } from "obsidian";
-import {
-	LiveView,
-	LiveViewManager,
-	getConnectionManager,
-} from "../LiveViews";
 import { curryLog } from "src/debug";
-import type { App, CachedMetadata } from "obsidian";
+import type { App, CachedMetadata, TFile } from "obsidian";
+import { Document, isDocument } from "../Document";
+import {
+	getApp,
+	getSharedFolders,
+	getEditorFile,
+	getRelayPlugin,
+	type MetadataBridge,
+} from "../editorContext";
+import { trackPromise } from "../trackPromise";
 
 export const invalidLinkSyncAnnotation = Annotation.define();
 
@@ -44,66 +47,85 @@ export class InvalidLinkPluginValue {
 	app?: App;
 	metadata: Map<number, CacheLink>;
 	editor: EditorView;
-	view?: LiveView<TextFileView>;
-	connectionManager?: LiveViewManager;
+	document?: Document;
 	decorationAnchors: number[];
 	decorations: DecorationSet;
 	cb: (data: string, cache: CachedMetadata) => void;
 	log: (message: string) => void = (message: string) => {};
+	private subscribedTFile?: TFile;
+	private metadataBridge?: MetadataBridge;
+	private destroyed = false;
 
 	constructor(editor: EditorView) {
 		this.editor = editor;
-		this.connectionManager = getConnectionManager(this.editor) ?? undefined;
 		this.decorations = Decoration.none;
 		this.decorationAnchors = [];
 		this.metadata = new Map();
 		this.cb = (data: string, cache: CachedMetadata) => {
-			if (!this.editor) return;
+			if (this.destroyed || !this.editor) return;
 			this.updateFromMetadata(cache);
 			this.editor.dispatch({
 				effects: metadataChangeEffect.of(null),
 			});
 		};
 
-		if (!this.connectionManager) {
-			curryLog(
-				"[InvalidLinkPluginValue]",
-				"warn",
-			)("ConnectionManager not found in InvalidLinkPlugin");
-			return;
-		}
-		this.app = this.connectionManager.app;
-		this.view = this.connectionManager.findView(editor);
+		this.app = getApp(this.editor) ?? undefined;
+		this.document = this.resolveDocument();
 
-		if (!this.view) {
+		if (!this.document) {
 			return;
 		}
 
 		this.log = curryLog(
-			`[InvalidLinkPluginValue][${this.view.view.file?.path}]`,
+			`[InvalidLinkPluginValue][${this.document.path}]`,
 			"debug",
 		);
 		this.log("created");
 
-		if (this.view.document) {
-			const hsm = this.view.document.hsm;
-			if (!hsm?.awaitState) return;
-			hsm.awaitState((s) => s.startsWith("active.")).then(() => {
-				const tfile = this.view?.document?.getTFile();
-				if (this.connectionManager && this.app && this.editor && tfile) {
-					this.connectionManager.onMeta(tfile, this.cb);
-					const fileCache = this.app.metadataCache.getFileCache(tfile);
-					if (fileCache) {
-						this.updateFromMetadata(fileCache);
-						this.editor.dispatch({
-							effects: metadataChangeEffect.of(null),
-						});
-					}
-				} else {
-					this.log("unable to subscribe to metadata updates");
+		const hsm = this.document.hsm;
+		if (!hsm?.awaitState) return;
+		trackPromise(
+			`invalidLink:awaitActive:${this.document.path}`,
+			hsm.awaitState((s) => s.startsWith("active.")),
+		).then(() => {
+			if (this.destroyed) return;
+			const tfile = this.document?.getTFile();
+			const plugin = getRelayPlugin(this.editor);
+			const metadataBridge = plugin?.metadataBridge;
+			if (metadataBridge && this.app && tfile) {
+				this.metadataBridge = metadataBridge;
+				metadataBridge.onMeta(tfile, this.cb);
+				this.subscribedTFile = tfile;
+				const fileCache = this.app.metadataCache.getFileCache(tfile);
+				if (fileCache) {
+					this.updateFromMetadata(fileCache);
+					this.editor.dispatch({
+						effects: metadataChangeEffect.of(null),
+					});
 				}
-			});
+			} else {
+				this.log("unable to subscribe to metadata updates");
+			}
+		});
+	}
+
+	private resolveDocument(): Document | undefined {
+		if (this.destroyed || !this.editor) return undefined;
+		if (this.document && this.document.tfile) {
+			return this.document;
 		}
+		const file = getEditorFile(this.editor);
+		if (!file) return undefined;
+		const sharedFolders = getSharedFolders(this.editor);
+		if (!sharedFolders) return undefined;
+		const folder = sharedFolders.lookup(file.path);
+		if (!folder) return undefined;
+		const vpath = folder.getVirtualPath(file.path);
+		const id = folder.syncStore.get(vpath);
+		if (id === undefined) return undefined;
+		const doc = folder.files.get(id);
+		if (!doc || !isDocument(doc)) return undefined;
+		return doc;
 	}
 
 	findInternalLinks(view: EditorView) {
@@ -142,25 +164,19 @@ export class InvalidLinkPluginValue {
 	}
 
 	updateFromMetadata(cache: CachedMetadata) {
-		if (this.connectionManager) {
-			this.view = this.connectionManager.findView(this.editor);
-		}
-		if (!this.view || !this.view.document || !this.app) return;
-		if (!this.view?.document?.sharedFolder) {
-			return;
-		}
-		if (!this.view?.document?.tfile) {
-			return;
-		}
+		this.document = this.resolveDocument();
+		if (!this.document || !this.app) return;
+		if (!this.document.sharedFolder) return;
+		if (!this.document.tfile) return;
 		const cacheLinks = new Map();
 		for (const link of cache?.links || []) {
 			const linkedFile = this.app.metadataCache.getFirstLinkpathDest(
 				link.link,
-				this.view.document.path,
+				this.document.path,
 			);
 			if (
 				linkedFile &&
-				!this.view.document.sharedFolder.checkPath(linkedFile.path)
+				!this.document.sharedFolder.checkPath(linkedFile.path)
 			) {
 				cacheLinks.set(link.position.start.offset, {
 					from: link.position.start.offset,
@@ -173,11 +189,11 @@ export class InvalidLinkPluginValue {
 		for (const embed of cache?.embeds || []) {
 			const linkedFile = this.app.metadataCache.getFirstLinkpathDest(
 				embed.link,
-				this.view.document.path,
+				this.document.path,
 			);
 			if (
 				linkedFile &&
-				!this.view.document.sharedFolder.checkPath(linkedFile.path)
+				!this.document.sharedFolder.checkPath(linkedFile.path)
 			) {
 				cacheLinks.set(embed.position.start.offset, {
 					from: embed.position.start.offset,
@@ -209,16 +225,10 @@ export class InvalidLinkPluginValue {
 		// The metadata cache is slower to update than the document.
 		// We use the cache to get link information, but rely on the document links for
 		// position information to avoid any delays or positioning bugs.
-		if (this.connectionManager) {
-			this.view = this.connectionManager.findView(this.editor);
-		}
-		if (!this.view || !this.view.document || !this.app) return;
-		if (!this.view?.document?.sharedFolder) {
-			return;
-		}
-		if (!this.view?.document?.tfile) {
-			return;
-		}
+		this.document = this.resolveDocument();
+		if (!this.document || !this.app) return;
+		if (!this.document.sharedFolder) return;
+		if (!this.document.tfile) return;
 
 		const invalidAnchors: number[] = [];
 		const cacheLinks = new Map(this.metadata);
@@ -226,7 +236,6 @@ export class InvalidLinkPluginValue {
 		for (const link of editorLinks) {
 			let _cacheLink = null;
 			for (const [cacheFrom, cacheLink] of cacheLinks) {
-				// Use metadata from link cache based on any overlap.
 				if (link.from <= cacheLink.to && link.to >= cacheLink.from) {
 					_cacheLink = cacheLink;
 					cacheLinks.delete(cacheFrom);
@@ -238,11 +247,11 @@ export class InvalidLinkPluginValue {
 			}
 			const linkedFile = this.app.metadataCache.getFirstLinkpathDest(
 				_cacheLink.link,
-				this.view.document.path,
+				this.document.path,
 			);
 			const isInvalid =
 				linkedFile &&
-				!this.view.document.sharedFolder.checkPath(linkedFile.path);
+				!this.document.sharedFolder.checkPath(linkedFile.path);
 			if (isInvalid) {
 				invalidAnchors.push(link.from);
 			}
@@ -287,11 +296,13 @@ export class InvalidLinkPluginValue {
 	}
 
 	destroy() {
-		if (this.connectionManager && this.view?.document?.tfile) {
-			this.connectionManager.offMeta(this.view.document.tfile);
+		this.destroyed = true;
+		if (this.subscribedTFile) {
+			this.metadataBridge?.offMeta(this.subscribedTFile);
+			this.subscribedTFile = undefined;
 		}
-		this.connectionManager = null as any;
-		this.view = undefined;
+		this.metadataBridge = undefined;
+		this.document = undefined;
 		this.metadata.clear();
 		this.metadata = null as any;
 		this.editor = null as any;

--- a/src/merge-hsm/MergeHSM.ts
+++ b/src/merge-hsm/MergeHSM.ts
@@ -418,6 +418,33 @@ export class MergeHSM implements TestableHSM, MachineHSM, SyncBridgeHost {
 		return this.localDoc;
 	}
 
+	async awaitPersistenceReady(): Promise<void> {
+		if (!this.localPersistence) {
+			await this.awaitState((statePath) => statePath !== "loading");
+		}
+		if (this.localPersistence && !this.localPersistence.synced) {
+			await this.localPersistence.whenSynced;
+		}
+	}
+
+	hasPersistenceUserData(): boolean {
+		return this.localPersistence?.hasUserData() ?? false;
+	}
+
+	async getPersistenceServerSynced(): Promise<boolean> {
+		const persistence = this.localPersistence as
+			| (IYDocPersistence & { getServerSynced?: () => Promise<boolean> })
+			| null;
+		return (await persistence?.getServerSynced?.()) ?? false;
+	}
+
+	async markPersistenceServerSynced(): Promise<void> {
+		const persistence = this.localPersistence as
+			| (IYDocPersistence & { markServerSynced?: () => Promise<void> })
+			| null;
+		await persistence?.markServerSynced?.();
+	}
+
 	/**
 	 * Get the length of the local document content.
 	 * localDoc is always alive in idle mode, so this returns immediately.

--- a/src/merge-hsm/MergeHSM.ts
+++ b/src/merge-hsm/MergeHSM.ts
@@ -62,7 +62,7 @@ import { processEvent } from "./machine-interpreter";
 import { MACHINE, createInterpreterConfig } from "./machine-definition";
 import type { InterpreterConfig, GuardFn, ActionFn, InvokeSourceFn } from "./types";
 import { DISK_ORIGIN, MACHINE_EDIT_ORIGIN, OpCapture } from "./undo";
-import { classifyUpdate, decodeSV, stateVectorsEqual, stateVectorIsAhead } from "./state-vectors";
+import { classifyUpdate, decodeSV, isEmptyDoc, stateVectorsEqual, stateVectorIsAhead } from "./state-vectors";
 import { SyncBridge } from "./SyncBridge";
 import type { SyncBridgeHost } from "./SyncBridge";
 
@@ -1565,17 +1565,35 @@ export class MergeHSM implements TestableHSM, MachineHSM, SyncBridgeHost {
 					this._bridge.flushOutbound();
 				}
 			},
-			setOffline: () => {
-				this._isOnline = false;
-				this._bridge.providerSynced = false;
-			},
-			markProviderSynced: () => {
-				this._bridge.providerSynced = true;
-			},
-			clearForkAndUpdateLCA: (_hsm, event) => {
-				this._fork = null;
-				this._ingestionTexts = [];
-				this.pendingIdleUpdates = null;
+				setOffline: () => {
+					this._isOnline = false;
+					this._providerSynced = false;
+					this._bridge.providerSynced = false;
+				},
+				markProviderSynced: () => {
+					this._providerSynced = true;
+					this._bridge.providerSynced = true;
+				},
+				maybeSignalPersistenceSyncedForRecovery: () => {
+					if (!this.matches("active.entering.awaitingPersistence")) {
+						return;
+					}
+					if (this._lca !== null) {
+						return;
+					}
+					if (!this.localPersistence || !this.localPersistence.synced) {
+						return;
+					}
+					const hasContent = this.localPersistence.hasUserData();
+					const remoteHasContent = !!this.remoteDoc && !isEmptyDoc(this.remoteDoc);
+					if (hasContent || remoteHasContent) {
+						this.send({ type: "PERSISTENCE_SYNCED", hasContent });
+					}
+				},
+				clearForkAndUpdateLCA: (_hsm, event) => {
+					this._fork = null;
+					this._ingestionTexts = [];
+					this.pendingIdleUpdates = null;
 				const result = (event as any).data;
 				if (result?.newLCA) {
 					this._lca = result.newLCA;
@@ -2470,11 +2488,7 @@ export class MergeHSM implements TestableHSM, MachineHSM, SyncBridgeHost {
 			this.localDoc
 		) {
 			// Only apply if localDoc has no CRDT history - safe to apply remote content.
-			// Check state vector size, not text content: an empty note with CRDT
-			// history (tombstones, deletions) must not be treated as "no content".
-			const localHasCrdtHistory = Y.encodeStateVector(this.localDoc).length > 1;
-
-			if (!localHasCrdtHistory) {
+			if (isEmptyDoc(this.localDoc)) {
 				Y.applyUpdate(this.localDoc, this.pendingIdleUpdates, this.remoteDoc);
 			}
 			// If localDoc has content, DO NOT apply - let flushInbound() handle it
@@ -2508,8 +2522,7 @@ export class MergeHSM implements TestableHSM, MachineHSM, SyncBridgeHost {
 		// initializeWithContent is only called on the upload path, not when
 		// opening a file in active mode after GUID remap.
 		const remoteHasContent =
-			this.remoteDoc &&
-			Y.encodeStateVector(this.remoteDoc).length > 1;
+			this.remoteDoc && !isEmptyDoc(this.remoteDoc);
 		if (hasContent || (this._lca === null && remoteHasContent)) {
 			this.send({ type: "PERSISTENCE_SYNCED", hasContent });
 		}
@@ -2524,12 +2537,7 @@ export class MergeHSM implements TestableHSM, MachineHSM, SyncBridgeHost {
 		if (!this.localDoc || !this.remoteDoc) return;
 
 		// Only apply if localDoc has no CRDT history and remoteDoc does.
-		// Check state vector size, not text content: an empty note with CRDT
-		// history (tombstones, deletions) must not be treated as "no content".
-		const localHasCrdtHistory = Y.encodeStateVector(this.localDoc).length > 1;
-		const remoteHasCrdtHistory = Y.encodeStateVector(this.remoteDoc).length > 1;
-
-		if (!localHasCrdtHistory && remoteHasCrdtHistory) {
+		if (isEmptyDoc(this.localDoc) && !isEmptyDoc(this.remoteDoc)) {
 			const update = Y.encodeStateAsUpdate(
 				this.remoteDoc,
 				Y.encodeStateVector(this.localDoc),

--- a/src/merge-hsm/MergeHSM.ts
+++ b/src/merge-hsm/MergeHSM.ts
@@ -26,6 +26,7 @@
 import * as Y from "yjs";
 import { diff3Merge } from "node-diff3";
 import { diff_match_patch } from "diff-match-patch";
+import { Conflict, computeConflict, type ConflictData } from "./conflict";
 import type {
 	MergeState,
 	MergeEvent,
@@ -156,17 +157,10 @@ export class MergeHSM implements TestableHSM, MachineHSM, SyncBridgeHost {
 	// Editor content from ACQUIRE_LOCK event, used for merge during reconciliation
 	private pendingEditorContent: string | null = null;
 
-	// Conflict data (enhanced for inline resolution)
-	private conflictData: {
-		base: string;
-		ours: string;
-		theirs: string;
-		oursLabel: string;
-		theirsLabel: string;
-		conflictRegions: ConflictRegion[];
-		resolvedIndices: Set<number>;
-		positionedConflicts: PositionedConflict[];
-	} | null = null;
+	// Active conflict resolution session. Built when conflict detected;
+	// cleared when resolved or superseded by a fresh sync. Read via
+	// `getConflictData()`.
+	private _conflict: Conflict | null = null;
 
 	// Track previous sync status for change detection
 	private lastSyncStatus: SyncStatusType = "synced";
@@ -456,17 +450,25 @@ export class MergeHSM implements TestableHSM, MachineHSM, SyncBridgeHost {
 		return 0;
 	}
 
-	getConflictData(): {
-		base: string;
-		ours: string;
-		theirs: string;
-		oursLabel: string;
-		theirsLabel: string;
-		conflictRegions?: ConflictRegion[];
-		resolvedIndices?: Set<number>;
-		positionedConflicts?: PositionedConflict[];
-	} | null {
-		return this.conflictData;
+	/**
+	 * Current conflict snapshot. Returns null when the file is clean.
+	 *
+	 * Returns the active resolution session if one is in progress; otherwise
+	 * derives one on demand from `_lca` + `localDoc` + `remoteDoc` (so a doc
+	 * sitting in `idle.diverged` without an open banner still reports correct
+	 * hunks). The on-demand derivation is cached on the HSM so subsequent
+	 * reads are O(1).
+	 */
+	getConflictData(): ConflictData | null {
+		if (this._conflict) return this._conflict.toData();
+		if (!this._lca?.contents || !this.localDoc || !this.remoteDoc) return null;
+		const base = this._lca.contents;
+		const ours = this.localDoc.getText("contents").toString();
+		const theirs = this.remoteDoc.getText("contents").toString();
+		const { hasConflict, regions } = computeConflict(base, ours, theirs);
+		if (!hasConflict) return null;
+		this._conflict = new Conflict({ base, ours, theirs, regions });
+		return this._conflict.toData();
 	}
 
 	getRemoteDoc(): Y.Doc | null {
@@ -1084,7 +1086,7 @@ export class MergeHSM implements TestableHSM, MachineHSM, SyncBridgeHost {
 			persistenceHasContent: (_hsm, event) => (event as any).hasContent === true,
 			persistenceEmptyAndProviderNotSynced: (_hsm, event) =>
 				(event as any).hasContent !== true && !this._providerSynced && this._lca !== null,
-			hasPreexistingConflict: () => this.conflictData !== null,
+			hasPreexistingConflict: () => this._conflict !== null,
 			isRecoveryMode: () => this._lca === null,
 		};
 	}
@@ -1274,7 +1276,7 @@ export class MergeHSM implements TestableHSM, MachineHSM, SyncBridgeHost {
 				const contents = (event as any).contents as string;
 
 				if (!this.localDoc || !this.remoteDoc) {
-					this.conflictData = null;
+					this._conflict = null;
 					return;
 				}
 
@@ -1327,32 +1329,27 @@ export class MergeHSM implements TestableHSM, MachineHSM, SyncBridgeHost {
 				// Clear fork and conflict state
 				this._fork = null;
 				this._ingestionTexts = [];
-				this.conflictData = null;
+				this._conflict = null;
 				this.pendingDiskContents = null;
 				this.pendingEditorContent = null;
 			},
 			storeConflictData: (_hsm, event) => {
 				const e = event as any;
-				const conflictRegions = e.conflictRegions ?? [];
-				const positionedConflicts = this.calculateConflictPositions(
-					conflictRegions,
-					e.ours,
-				);
-				this.conflictData = {
+				const regions = e.conflictRegions ?? [];
+				this._conflict = new Conflict({
 					base: e.base,
 					ours: e.ours,
 					theirs: e.theirs,
 					oursLabel: e.oursLabel ?? "Remote",
 					theirsLabel: e.theirsLabel ?? "Local file",
-					conflictRegions,
-					resolvedIndices: new Set(),
-					positionedConflicts,
-				};
-				if (positionedConflicts.length > 0) {
+					regions,
+				});
+				const positions = this._conflict.positions;
+				if (positions.length > 0) {
 					this.emitEffect({
 						type: "SHOW_CONFLICT_DECORATIONS",
-						conflictRegions,
-						positions: positionedConflicts,
+						conflictRegions: regions,
+						positions,
 					});
 				}
 			},
@@ -1920,7 +1917,7 @@ export class MergeHSM implements TestableHSM, MachineHSM, SyncBridgeHost {
 		// If fork-reconcile already detected a conflict, don't re-attempt the
 		// merge — the conflict data is authoritative and must be surfaced to
 		// the user when they open the file.
-		if (this.conflictData) {
+		if (this._conflict) {
 			this.pendingDiskContents = null;
 			this.pendingIdleUpdates = null;
 			return { success: false };
@@ -2119,23 +2116,17 @@ export class MergeHSM implements TestableHSM, MachineHSM, SyncBridgeHost {
 		}
 
 		// Merge conflict — can't auto-resolve.
-		// Populate conflictData so the diff UI is available when the user opens
-		// the file from idle.diverged. Without this, CRDT merge during provider
-		// sync would make localDoc and disk identical, causing the active.entering
-		// reconciliation to skip conflict detection (localText === diskText).
-		this.conflictData = {
+		// Build the active conflict so the diff UI is available when the user
+		// opens the file from idle.diverged. Without this, CRDT merge during
+		// provider sync would make localDoc and disk identical, causing the
+		// active.entering reconciliation to skip conflict detection
+		// (localText === diskText).
+		this._conflict = new Conflict({
 			base: fork.base,
 			ours: localContent,
 			theirs: remoteContent,
-			oursLabel: "Local",
-			theirsLabel: "Remote",
-			conflictRegions: mergeResult.conflictRegions ?? [],
-			resolvedIndices: new Set(),
-			positionedConflicts: this.calculateConflictPositions(
-				mergeResult.conflictRegions ?? [],
-				localContent,
-			),
-		};
+			regions: mergeResult.conflictRegions ?? [],
+		});
 		return { success: false };
 	}
 
@@ -2274,19 +2265,14 @@ export class MergeHSM implements TestableHSM, MachineHSM, SyncBridgeHost {
 
 		const conflictRegions = computeTwoWayConflictRegions(localText, diskText);
 
-		this.conflictData = {
+		this._conflict = new Conflict({
 			base: localText,
 			ours: localText,
 			theirs: diskText,
 			oursLabel: "Remote",
 			theirsLabel: "Local file",
-			conflictRegions,
-			resolvedIndices: new Set(),
-			positionedConflicts: this.calculateConflictPositions(
-				conflictRegions,
-				localText,
-			),
-		};
+			regions: conflictRegions,
+		});
 
 		this.send({
 			type: "MERGE_CONFLICT",
@@ -2346,20 +2332,15 @@ export class MergeHSM implements TestableHSM, MachineHSM, SyncBridgeHost {
 			// by the mergeRemoteToLocal entry action on active.tracking.
 			this.pendingEditorContent = null;
 		} else {
-			// Merge has conflicts - populate conflictData for banner/diff view
-			this.conflictData = {
+			// Merge has conflicts - build conflict for banner/diff view
+			this._conflict = new Conflict({
 				base: baseText,
 				ours: localText,
 				theirs: diskText,
 				oursLabel: "Remote",
 				theirsLabel: "Local file",
-				conflictRegions: mergeResult.conflictRegions ?? [],
-				resolvedIndices: new Set(),
-				positionedConflicts: this.calculateConflictPositions(
-					mergeResult.conflictRegions ?? [],
-					localText,
-				),
-			};
+				regions: mergeResult.conflictRegions ?? [],
+			});
 
 			// Send MERGE_CONFLICT to transition to conflict state
 			this.send({
@@ -2853,100 +2834,21 @@ export class MergeHSM implements TestableHSM, MachineHSM, SyncBridgeHost {
 	}
 
 	/**
-	 * Calculate character positions for conflict regions based on line numbers.
-	 */
-	private calculateConflictPositions(
-		regions: ConflictRegion[],
-		localContent: string,
-	): PositionedConflict[] {
-		if (regions.length === 0) return [];
-
-		// Find each region's oursContent in the local text by string search.
-		// baseStart/baseEnd are diff3 token indices (not line numbers), so
-		// we cannot use them as line-map lookups.  Searching for the literal
-		// oursContent is reliable as long as each hunk's text is unique.
-		let searchFrom = 0;
-		return regions.map((region, index) => {
-			const text = region.oursContent;
-			if (!text) {
-				return {
-					index,
-					localStart: searchFrom,
-					localEnd: searchFrom,
-					oursContent: region.oursContent,
-					theirsContent: region.theirsContent,
-				};
-			}
-			const pos = localContent.indexOf(text, searchFrom);
-			const start = pos !== -1 ? pos : searchFrom;
-			const end = pos !== -1 ? pos + text.length : searchFrom;
-			searchFrom = end;
-			return {
-				index,
-				localStart: start,
-				localEnd: end,
-				oursContent: region.oursContent,
-				theirsContent: region.theirsContent,
-			};
-		});
-	}
-
-	/**
-	 * Recalculate conflict positions after a hunk is resolved.
-	 * Positions shift when earlier hunks are resolved.
-	 */
-	private recalculateConflictPositions(): void {
-		if (!this.conflictData || !this.localDoc) return;
-
-		const currentContent = this.localDoc.getText("contents").toString();
-		this.conflictData.ours = currentContent;
-
-		const positioned = this.conflictData.positionedConflicts;
-
-		// For each unresolved conflict, find its oursContent in the updated document
-		for (let i = 0; i < positioned.length; i++) {
-			if (this.conflictData.resolvedIndices.has(i)) continue;
-
-			const conflict = positioned[i];
-			const searchText = conflict.oursContent;
-
-			if (!searchText) {
-				// Empty oursContent — zero-width region; find by surrounding context
-				conflict.localStart = 0;
-				conflict.localEnd = 0;
-				continue;
-			}
-
-			const foundIndex = currentContent.indexOf(searchText, Math.max(0, conflict.localStart - 100));
-			if (foundIndex !== -1) {
-				conflict.localStart = foundIndex;
-				conflict.localEnd = foundIndex + searchText.length;
-			} else {
-				// Fallback: search from the beginning
-				const fallbackIndex = currentContent.indexOf(searchText);
-				if (fallbackIndex !== -1) {
-					conflict.localStart = fallbackIndex;
-					conflict.localEnd = fallbackIndex + searchText.length;
-				}
-			}
-		}
-	}
-
-	/**
 	 * Handle per-hunk conflict resolution from inline decorations.
 	 */
 	private handleResolveHunk(event: ResolveHunkEvent): void {
 		// Allow resolving from either bannerShown or resolving state
 		if (!this._statePath.includes("conflict")) return;
-		if (!this.conflictData || !this.localDoc) return;
+		if (!this._conflict || !this.localDoc) return;
 
 		const { index, resolution } = event;
+		const conflict = this._conflict;
 
 		// Skip if already resolved
-		if (this.conflictData.resolvedIndices.has(index)) return;
+		if (conflict.resolved.has(index)) return;
 
-		const region = this.conflictData.conflictRegions[index];
-		const positioned = this.conflictData.positionedConflicts[index];
+		const region = conflict.regions[index];
+		const positioned = conflict.positions[index];
 
 		if (!region || !positioned) return;
 
@@ -2982,7 +2884,7 @@ export class MergeHSM implements TestableHSM, MachineHSM, SyncBridgeHost {
 		}, this);
 
 		// Mark as resolved
-		this.conflictData.resolvedIndices.add(index);
+		conflict.markResolved(index);
 
 		// Emit effect to hide this conflict's decoration
 		this.emitEffect({
@@ -3007,20 +2909,14 @@ export class MergeHSM implements TestableHSM, MachineHSM, SyncBridgeHost {
 		// corrupting the editor.
 		this.lastKnownEditorText = afterText;
 
-		// Update stored local content
-		this.conflictData.ours = afterText;
-
-		// Recalculate positions for remaining conflicts (they shift!)
-		this.recalculateConflictPositions();
+		// Update stored local content + reposition the remaining hunks (they shift!)
+		conflict.updateOurs(afterText);
 
 		// Sync to remote → collaborators see immediately
 		this._bridge.flushOutbound();
 
 		// Check if all conflicts resolved
-		if (
-			this.conflictData.resolvedIndices.size ===
-			this.conflictData.conflictRegions.length
-		) {
+		if (conflict.isFullyResolved) {
 			// All hunks resolved — localDoc already has the final content.
 			const finalContent = this.localDoc.getText("contents").toString();
 			this.send({ type: "RESOLVE", contents: finalContent });
@@ -3564,7 +3460,7 @@ function extractConflictRegions(
 /**
  * Build per-hunk ConflictRegions from a two-way diff (no LCA).
  * Uses local text as the positional reference so that
- * calculateConflictPositions can find each hunk by string search.
+ * `positionRegions` (in conflict.ts) can find each hunk by string search.
  */
 function computeTwoWayConflictRegions(
 	localText: string,

--- a/src/merge-hsm/MergeManager.ts
+++ b/src/merge-hsm/MergeManager.ts
@@ -32,6 +32,7 @@ import { ObservableMap } from '../observable/ObservableMap';
 import { validateUpdate } from '../storage/yjs-validation';
 import { classifyUpdate as classifyUpdateSV } from './state-vectors';
 import { metrics, curryLog } from '../debug';
+import { trackPromise } from '../trackPromise';
 
 // =============================================================================
 // Types
@@ -826,7 +827,7 @@ export class MergeManager {
       hsm.send({ type: 'RELEASE_LOCK' });
       this.activeDocs.delete(guid);
       // Wait for cleanup to complete (IndexedDB writes)
-      await hsm.awaitCleanup();
+      await trackPromise(`awaitCleanup:${guid}`, hsm.awaitCleanup());
     }
 
     if (this.destroyed) return;
@@ -943,6 +944,22 @@ export class MergeManager {
       this._trackedRemoteSV.set(guid, sv);
     } catch {
       // Parse failure — remove tracking so next event falls back to HTTP
+      this._trackedRemoteSV.delete(guid);
+    }
+  }
+
+  /**
+   * Seed the tracked SV directly from raw state vector bytes. Used when the
+   * server supplies the SV (e.g. the subdoc-index response on reconnect),
+   * rather than a full update we'd derive the SV from.
+   */
+  seedTrackedRemoteSVFromBytes(guid: string, svBytes: Uint8Array): void {
+    try {
+      const sv = Y.decodeStateVector(svBytes);
+      this._trackedRemoteSV.set(guid, sv);
+    } catch {
+      // Parse failure — remove tracking so next event falls back to HTTP
+      // keyframe, same as seedTrackedRemoteSV.
       this._trackedRemoteSV.delete(guid);
     }
   }

--- a/src/merge-hsm/MergeManager.ts
+++ b/src/merge-hsm/MergeManager.ts
@@ -209,8 +209,6 @@ export class MergeManager {
   // Used for idle mode sync status display without opening per-document IDBs
   private _localStateVectorCache = new Map<string, Uint8Array | null>();
 
-  // Documents with an in-flight async load (createHSM → loadState)
-  private _pendingLoads = new Set<string>();
 
   // =========================================================================
   // Hibernation State
@@ -436,9 +434,7 @@ export class MergeManager {
 
     // Async-load full per-document state from IDB (includes lca.contents and fork)
     const loadStateFn = this.loadState ?? (() => Promise.resolve(null));
-    this._pendingLoads.add(guid);
     loadStateFn(guid).then((state) => {
-      this._pendingLoads.delete(guid);
       if (this.destroyed) return;
       // Build full LCA from IDB state (the source of truth for contents)
       const lca: LCAState | null = state?.lca
@@ -453,7 +449,6 @@ export class MergeManager {
       });
       hsm.send({ type: 'SET_MODE_IDLE' });
     }).catch((err) => {
-      this._pendingLoads.delete(guid);
       this._error(`Failed to load state for ${guid}: ${err}`);
       // On IDB failure, pass null LCA — metadata without contents would
       // produce wrong merge results. The HSM treats null as "no prior state".
@@ -800,9 +795,6 @@ export class MergeManager {
       const statePath = hsm.state.statePath;
 
       if (statePath === 'loading') {
-        // Skip HSMs with an in-flight async load — they will receive
-        // SET_MODE_IDLE when the load completes in createHSM.
-        if (this._pendingLoads.has(guid)) continue;
         if (activeGuids.has(guid)) {
           hsm.send({ type: 'SET_MODE_ACTIVE' });
         } else {
@@ -824,6 +816,7 @@ export class MergeManager {
    * Waits for IndexedDB writes to complete before returning.
    */
   async unload(guid: string): Promise<void> {
+    if (this.destroyed) return;
     const doc = this._getDocument(guid);
     const hsm = doc?.hsm;
     if (!hsm) return;
@@ -835,6 +828,8 @@ export class MergeManager {
       // Wait for cleanup to complete (IndexedDB writes)
       await hsm.awaitCleanup();
     }
+
+    if (this.destroyed) return;
 
     // HSM stays alive in idle.* state
     // Sync status preserved
@@ -1034,6 +1029,23 @@ export class MergeManager {
     this._wakeQueue.length = 0;
     this._wakingDocs.clear();
     this._warmLRU.clear();
+
+    // These callbacks close over SharedFolder and related plugin services.
+    // Clear them so a retained MergeManager shell does not pin the folder graph.
+    this._getVaultId = null as any;
+    this._getDocument = null as any;
+    this.timeProvider = null as any;
+    this.hashFn = undefined;
+    this.loadAllStates = undefined;
+    this.onEffect = undefined;
+    this.getDiskState = undefined;
+    this._persistIndex = undefined;
+    this.loadState = undefined;
+    this.createPersistence = undefined;
+    this.getPersistenceMetadata = undefined;
+    this.userId = undefined;
+    this._yaml = null;
+    this._onTransition = undefined;
   }
 
   // ===========================================================================
@@ -1086,6 +1098,9 @@ export class MergeManager {
    * Resets the hibernate timer since the doc is actively receiving updates.
    */
   private touchWarmLRU(guid: string): void {
+    if (this.destroyed || !this.timeProvider) {
+      return;
+    }
     this._warmLRU.delete(guid);
     this._warmLRU.set(guid, this.timeProvider.now());
   }

--- a/src/merge-hsm/conflict.ts
+++ b/src/merge-hsm/conflict.ts
@@ -1,0 +1,219 @@
+/**
+ * Conflict — pure compute primitives plus a small stateful wrapper for the
+ * lifetime of a single conflict resolution session.
+ *
+ * Two layers:
+ * 1. `computeConflict(base, ours, theirs)` and `positionRegions(regions, local)`
+ *    are pure functions. Test in isolation, share between callers.
+ * 2. `Conflict` wraps frozen regions plus mutable resolution/position state for
+ *    the duration of a resolution session. Constructed when a conflict is
+ *    detected; thrown away and re-built when underlying materials change
+ *    (e.g. after a sync event delivers new remote/disk content).
+ */
+
+import { diff3Merge } from "node-diff3";
+import type { ConflictRegion, PositionedConflict, PositionedChange } from "./types";
+
+export interface ConflictData {
+	base: string;
+	ours: string;
+	theirs: string;
+	oursLabel: string;
+	theirsLabel: string;
+	conflictRegions: ConflictRegion[];
+	resolvedIndices: Set<number>;
+	positionedConflicts: PositionedConflict[];
+}
+
+/**
+ * Pure 3-way diff. Returns the conflict regions when sides disagree, or the
+ * merged content when they don't. Tokenizes by newline so regions are
+ * line-aligned.
+ */
+export function computeConflict(
+	base: string,
+	ours: string,
+	theirs: string,
+): { hasConflict: boolean; regions: ConflictRegion[]; merged?: string } {
+	const tok = (s: string) => s.split(/(\n)/);
+	const result = diff3Merge(tok(ours), tok(base), tok(theirs));
+	const hasConflict = result.some(
+		(r: { ok?: string[]; conflict?: { a: string[]; o: string[]; b: string[] } }) =>
+			"conflict" in r,
+	);
+	if (hasConflict) {
+		return { hasConflict: true, regions: extractRegions(result) };
+	}
+	const mergedTokens: string[] = [];
+	for (const region of result) {
+		if ("ok" in region && region.ok) mergedTokens.push(...region.ok);
+	}
+	return { hasConflict: false, regions: [], merged: mergedTokens.join("") };
+}
+
+function extractRegions(
+	result: Array<{
+		ok?: string[];
+		conflict?: { a: string[]; o: string[]; b: string[] };
+	}>,
+): ConflictRegion[] {
+	const regions: ConflictRegion[] = [];
+	let lineOffset = 0;
+	for (const region of result) {
+		if ("conflict" in region && region.conflict) {
+			const { a: localTokens, o: baseTokens, b: remoteTokens } = region.conflict;
+			regions.push({
+				baseStart: lineOffset,
+				baseEnd: lineOffset + (baseTokens?.length ?? 0),
+				oursContent: localTokens?.join("") ?? "",
+				theirsContent: remoteTokens?.join("") ?? "",
+			});
+			lineOffset += baseTokens?.length ?? 0;
+		} else if ("ok" in region && region.ok) {
+			lineOffset += region.ok.length;
+		}
+	}
+	return regions;
+}
+
+/**
+ * Locate each region's `oursContent` in the current local text. Used for
+ * placing inline editor decorations. Cheap (string search) — safe to call
+ * after every text edit; no diff3 re-run.
+ *
+ * Empty `oursContent` (zero-width regions) collapse to the running search
+ * position.
+ */
+export function positionRegions(
+	regions: ConflictRegion[],
+	localContent: string,
+): PositionedConflict[] {
+	if (regions.length === 0) return [];
+	let searchFrom = 0;
+	return regions.map((region, index) => {
+		const text = region.oursContent;
+		if (!text) {
+			return {
+				index,
+				localStart: searchFrom,
+				localEnd: searchFrom,
+				oursContent: text,
+				theirsContent: region.theirsContent,
+			};
+		}
+		const pos = localContent.indexOf(text, searchFrom);
+		const start = pos !== -1 ? pos : searchFrom;
+		const end = pos !== -1 ? pos + text.length : searchFrom;
+		searchFrom = end;
+		return {
+			index,
+			localStart: start,
+			localEnd: end,
+			oursContent: text,
+			theirsContent: region.theirsContent,
+		};
+	});
+}
+
+/**
+ * Re-position only the unresolved regions. Used during in-progress
+ * resolution where earlier hunks have shifted later hunks' offsets.
+ * Searches for each remaining hunk's `oursContent` near its previous
+ * position before falling back to a full scan.
+ */
+export function repositionUnresolved(
+	current: PositionedConflict[],
+	resolved: ReadonlySet<number>,
+	localContent: string,
+): PositionedConflict[] {
+	return current.map((c, i) => {
+		if (resolved.has(i)) return c;
+		const text = c.oursContent;
+		if (!text) return { ...c, localStart: 0, localEnd: 0 };
+		const near = localContent.indexOf(text, Math.max(0, c.localStart - 100));
+		if (near !== -1) return { ...c, localStart: near, localEnd: near + text.length };
+		const fallback = localContent.indexOf(text);
+		if (fallback !== -1) return { ...c, localStart: fallback, localEnd: fallback + text.length };
+		return c;
+	});
+}
+
+/**
+ * Conflict — a single resolution session.
+ *
+ * Construction = full diff (frozen regions). Lifetime methods are cheap:
+ * `updateOurs(text)` repositions the unresolved regions; `markResolved(i)`
+ * records user choice. When underlying materials (base/theirs) change due
+ * to sync events, throw this away and build a new `Conflict` from a fresh
+ * `computeConflict` call.
+ */
+export class Conflict {
+	readonly base: string;
+	readonly theirs: string;
+	readonly oursLabel: string;
+	readonly theirsLabel: string;
+	readonly regions: ConflictRegion[];
+	readonly resolved = new Set<number>();
+	private _ours: string;
+	private _positions: PositionedConflict[];
+
+	constructor(args: {
+		base: string;
+		ours: string;
+		theirs: string;
+		oursLabel?: string;
+		theirsLabel?: string;
+		regions: ConflictRegion[];
+	}) {
+		this.base = args.base;
+		this._ours = args.ours;
+		this.theirs = args.theirs;
+		this.oursLabel = args.oursLabel ?? "Local";
+		this.theirsLabel = args.theirsLabel ?? "Remote";
+		this.regions = args.regions;
+		this._positions = positionRegions(this.regions, this._ours);
+	}
+
+	get ours(): string {
+		return this._ours;
+	}
+
+	get positions(): PositionedConflict[] {
+		return this._positions;
+	}
+
+	/**
+	 * Update the local content and reposition unresolved hunks. Called after
+	 * the editor applies a resolution (which deletes a hunk and shifts the
+	 * remaining ones). No diff3 — only string search.
+	 */
+	updateOurs(newOurs: string): void {
+		this._ours = newOurs;
+		this._positions = repositionUnresolved(this._positions, this.resolved, newOurs);
+	}
+
+	markResolved(index: number): void {
+		this.resolved.add(index);
+	}
+
+	get isFullyResolved(): boolean {
+		return this.resolved.size === this.regions.length;
+	}
+
+	/** Snapshot in the `ConflictData` shape for read-only callers. */
+	toData(): ConflictData {
+		return {
+			base: this.base,
+			ours: this._ours,
+			theirs: this.theirs,
+			oursLabel: this.oursLabel,
+			theirsLabel: this.theirsLabel,
+			conflictRegions: this.regions,
+			resolvedIndices: this.resolved,
+			positionedConflicts: this._positions,
+		};
+	}
+}
+
+// Re-export so MergeHSM.ts has one place to import position helpers from.
+export type { PositionedChange };

--- a/src/merge-hsm/integration/HSMEditorPlugin.ts
+++ b/src/merge-hsm/integration/HSMEditorPlugin.ts
@@ -78,7 +78,15 @@ class HSMEditorPluginValue implements PluginValue {
     const folder = connectionManager.sharedFolders.lookup(file.path);
     if (!folder) return null;
 
-    return folder.proxy.getDoc(file.path) as Document;
+    try {
+      return folder.proxy.getDoc(file.path) as Document;
+    } catch (error) {
+      this.debug("resolveCurrentDocument failed", {
+        filePath: file.path,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return null;
+    }
   }
 
   /**

--- a/src/merge-hsm/machine-definition.ts
+++ b/src/merge-hsm/machine-definition.ts
@@ -30,6 +30,10 @@ import { normalizeToCandidates } from "./machine-interpreter";
  * Spread into each idle state's `on` map to avoid repetition.
  */
 const IDLE_LIFECYCLE: Record<string, EventHandler> = {
+	// PERSISTENCE_LOADED may arrive after an early SET_MODE_IDLE/SET_MODE_ACTIVE
+	// (e.g. startup/reload races). Re-enter idle.loading so always-transitions
+	// re-evaluate with the loaded LCA/fork data.
+	PERSISTENCE_LOADED: { target: 'idle.loading', actions: ['storePersistenceData'] },
 	ACQUIRE_LOCK: { target: 'active.entering.awaitingPersistence', actions: ['storeEditorContent'] },
 	UNLOAD: { target: 'unloading', actions: ['beginUnload'] },
 	LOAD: { target: 'loading', actions: ['initializeFromLoad'] },
@@ -286,6 +290,9 @@ export const MACHINE: MachineDefinition = {
 
 	'active.loading': {
 		on: {
+			// Late persistence payload (after an early SET_MODE_ACTIVE) should
+			// still hydrate LCA/fork data for entering reconciliation.
+			PERSISTENCE_LOADED: { target: 'active.loading', actions: ['storePersistenceData'] },
 			ACQUIRE_LOCK: { target: 'active.entering.awaitingPersistence', actions: ['storeEditorContent'] },
 			CM6_CHANGE: { target: 'active.loading', actions: ['accumulateCM6Change'] },
 			REMOTE_UPDATE: { target: 'active.loading', actions: ['applyRemoteToRemoteDoc', 'accumulateRemoteUpdate'] },
@@ -299,13 +306,30 @@ export const MACHINE: MachineDefinition = {
 	'active.entering.awaitingPersistence': {
 		entry: ['createYDocs'],
 		on: {
+			// If persistence arrives after we already entered active.entering,
+			// hydrate state in-place and let existing guards continue.
+			PERSISTENCE_LOADED: {
+				target: 'active.entering.awaitingPersistence',
+				actions: ['storePersistenceData', 'maybeSignalPersistenceSyncedForRecovery'],
+			},
 			PERSISTENCE_SYNCED: [
 				{ target: 'active.entering.reconciling', guard: 'persistenceHasContent' },
 				{ target: 'active.tracking', guard: 'persistenceEmptyAndProviderNotSynced', actions: ['clearEnteringState'] },
 				{ target: 'active.entering.reconciling', actions: ['applyRemoteToLocalIfNeeded'] },
 			],
+			PROVIDER_SYNCED: {
+				target: 'active.entering.awaitingPersistence',
+				actions: ['markProviderSynced', 'maybeSignalPersistenceSyncedForRecovery'],
+			},
 			CM6_CHANGE: { target: 'active.entering.awaitingPersistence', actions: ['accumulateCM6Change'] },
-			REMOTE_UPDATE: { target: 'active.entering.awaitingPersistence', actions: ['applyRemoteToRemoteDoc', 'accumulateRemoteUpdate'] },
+			REMOTE_UPDATE: {
+				target: 'active.entering.awaitingPersistence',
+				actions: [
+					'applyRemoteToRemoteDoc',
+					'accumulateRemoteUpdate',
+					'maybeSignalPersistenceSyncedForRecovery',
+				],
+			},
 			DISK_CHANGED: { target: 'active.entering.awaitingPersistence', actions: ['storeDiskMetadata', 'accumulateDiskChanged'] },
 			RELEASE_LOCK: { target: 'unloading', actions: ['beginReleaseLock'] },
 			UNLOAD: { target: 'unloading', actions: ['beginUnload'] },

--- a/src/merge-hsm/state-vectors.ts
+++ b/src/merge-hsm/state-vectors.ts
@@ -109,6 +109,14 @@ export function classifyUpdate(
 	return hasNewOps ? "apply" : "stale";
 }
 
+/**
+ * Check whether a Y.Doc is empty (no CRDT operations from any client).
+ * An empty Y.Doc has a zero-entry state vector.
+ */
+export function isEmptyDoc(doc: Y.Doc): boolean {
+	return decodeSV(Y.encodeStateVector(doc)).size === 0;
+}
+
 // ---- Convenience wrappers for encoded Uint8Array inputs ----
 
 /**

--- a/src/merge-hsm/testing/createTestHSM.ts
+++ b/src/merge-hsm/testing/createTestHSM.ts
@@ -198,6 +198,7 @@ export interface TestableHSM {
   awaitForkReconcile(): Promise<void>;
   hasFork(): boolean;
   awaitState(predicate: (statePath: string) => boolean): Promise<void>;
+  getConflictData(): { base: string; ours: string; theirs: string } | null;
 }
 
 // =============================================================================

--- a/src/plugins/ViewHookPlugin.ts
+++ b/src/plugins/ViewHookPlugin.ts
@@ -8,6 +8,7 @@ import { diffMatchPatch } from "../y-diffMatchPatch";
 import { flags } from "../flagManager";
 import { HasLogging } from "../debug";
 import type { ChangeSpec } from "@codemirror/state";
+import { trackPromise } from "../trackPromise";
 import diff_match_patch from "diff-match-patch";
 import { MetadataRenderer } from "./MetadataRenderer";
 
@@ -50,7 +51,7 @@ export class ViewHookPlugin extends HasLogging {
 		if (!localDoc) {
 			const hsm = this.document.hsm;
 			if (hsm?.awaitState) {
-				await hsm.awaitState((s) => s.startsWith("active."));
+				await trackPromise(`viewHook:awaitActive:${this.document.guid}`, hsm.awaitState((s) => s.startsWith("active.")));
 			}
 			localDoc = this.document.localDoc;
 		}

--- a/src/trackPromise.ts
+++ b/src/trackPromise.ts
@@ -16,7 +16,7 @@ export interface CompletedEntry {
 
 // Module-level ring buffer of recent completions. Survives plugin reload so
 // completed promises from a prior instance remain inspectable.
-const RECENT_CAPACITY = 100;
+const RECENT_CAPACITY = 1000;
 const _recent: CompletedEntry[] = [];
 
 function recordSettled(entry: TrackedEntry, state: "fulfilled" | "rejected"): void {

--- a/src/ui/FolderNav.ts
+++ b/src/ui/FolderNav.ts
@@ -895,10 +895,15 @@ export class FolderNavigationDecorations {
 		this.treeState.forEach((walker) => walker.destroy());
 		this.treeState.clear();
 		this.offLayoutChange();
+		this.offLayoutChange = null as any;
 
 		this.vault = null as any;
 		this.workspace = null as any;
 		this.sharedFolders = null as any;
 		this.backgroundSync = null as any;
+		this.treeState = null as any;
+		this.globalSubs = null as any;
+		this.subscribedFolders = null as any;
+		this.subscribedFolderFsets = null as any;
 	}
 }


### PR DESCRIPTION
## Summary
- restore the missing `src/editorContext.ts` module on current `merge-hsm` head `39ed0d5`
- provide the helper surface currently imported by ShareLink, InvalidLink, and `main.ts`
- keep the repair narrow to the missing file plus `MetadataBridge` type export

## Validation
- `node esbuild.config.mjs staging`
- `npm test -- --runInBand`
- targeted workflow dispatch from this branch against `origin/fix/editor-context-merge-hsm-live` (`tests=test-basic-open-close`)
