### PR TITLE
fix: restore merge-hsm build and conflict unit gate

### DIFF
--- a/src/AwarenessViewPlugin.ts
+++ b/src/AwarenessViewPlugin.ts
@@ -1,12 +1,15 @@
 import { HasLogging } from "./debug";
-import { View } from "obsidian";
 import UserAwareness from "./components/UserAwareness.svelte";
 import { trackPromise } from "./trackPromise";
 import type { HasProvider } from "./HasProvider";
 
+type AwarenessHostView = {
+	containerEl: HTMLElement;
+};
+
 export interface AwarenessHost {
-	/** The Obsidian view whose containerEl owns the avatar overlay. */
-	view: View;
+	/** The view-like object whose containerEl owns the avatar overlay. */
+	view: AwarenessHostView;
 	/**
 	 * The provider-backed doc (Document or Canvas). Must expose `_provider`,
 	 * `whenReady()`, `guid`, and optionally `path` for logger tagging.

--- a/src/merge-hsm/MergeHSM.ts
+++ b/src/merge-hsm/MergeHSM.ts
@@ -1446,24 +1446,25 @@ export class MergeHSM implements TestableHSM, MachineHSM, SyncBridgeHost {
 				);
 				this._bridge.syncToLocal(remoteUpdate);
 
-				// Step 3: DMP the resolved text onto localDoc. After the CRDT
-				// merge the text may not match what the user chose (e.g. they
-				// accepted ours, or merged individual hunks). DMP fixes it up.
-				this.applyContentToLocalDoc(contents);
-
-				// Step 4: Dispatch resolved content to CM6. The localDoc
-				// observer skips origin=this, so we emit explicitly. Use the
-				// current editor buffer after the remote merge above, not the
-				// stale cached value from before RESOLVE. Otherwise the same
-				// patch can be replayed onto an editor that already matches the
-				// resolved text, progressively corrupting the frontmatter.
-				const resolvedText = this.localDoc.getText("contents").toString();
+				// Step 3: Capture the current editor buffer after the CRDT merge
+				// but before applying the selected resolution. A live EditorViewRef
+				// reads through to the current editor; reading it after localDoc is
+				// mutated can hide the CM6 patch that direct RESOLVE still needs.
 				const beforeText =
 					this.readCurrentEditorText()
 					?? this.lastKnownEditorText
 					?? this.pendingDiskContents
 					?? this.pendingEditorContent
 					?? "";
+
+				// Step 4: DMP the resolved text onto localDoc. After the CRDT
+				// merge the text may not match what the user chose (e.g. they
+				// accepted ours, or merged individual hunks). DMP fixes it up.
+				this.applyContentToLocalDoc(contents);
+
+				// Step 5: Dispatch resolved content to CM6. The localDoc
+				// observer skips origin=this, so we emit explicitly.
+				const resolvedText = this.localDoc.getText("contents").toString();
 				this.crdtLog(
 					`resolveConflict: contents=${resolvedText.length} chars, ` +
 					`before=${beforeText.length} chars, ` +
@@ -1480,7 +1481,7 @@ export class MergeHSM implements TestableHSM, MachineHSM, SyncBridgeHost {
 				}
 				this.lastKnownEditorText = resolvedText;
 
-				// Step 5: Sync localDoc → remoteDoc and server. Histories are
+				// Step 6: Sync localDoc → remoteDoc and server. Histories are
 				// now converged so the update is clean.
 				this._bridge.syncToRemote(Y.encodeStateAsUpdate(this.localDoc));
 				this._bridge.clearOutboundQueue();

--- a/src/merge-hsm/integration/CM6Integration.ts
+++ b/src/merge-hsm/integration/CM6Integration.ts
@@ -9,7 +9,7 @@
  */
 
 import type { EditorView, ViewUpdate } from "@codemirror/view";
-import { Transaction } from "@codemirror/state";
+import { Transaction, type TransactionSpec } from "@codemirror/state";
 import { editorInfoField, getFrontMatterInfo } from "obsidian";
 import type { MergeHSM } from "../MergeHSM";
 import type { PositionedChange } from "../types";
@@ -173,11 +173,7 @@ export class CM6Integration {
 			this.log(
 				`dispatchToEditor: ${changes.length} changes, editor=${editorBefore} chars before`,
 			);
-			const dispatchSpec: {
-				changes: { from: number; to: number; insert: string }[];
-				annotations: unknown[];
-				filter?: boolean;
-			} = {
+			const dispatchSpec: TransactionSpec = {
 				changes: cmChanges,
 				// Mark as coming from Yjs/HSM to prevent feedback loops
 				annotations: [ySyncAnnotation.of(this.view)],
@@ -202,11 +198,7 @@ export class CM6Integration {
 							this.log(
 								`dispatchToEditor (rAF): applying ${changes.length} deferred changes, editor=${editorBefore} chars before`,
 							);
-							const dispatchSpec: {
-								changes: { from: number; to: number; insert: string }[];
-								annotations: unknown[];
-								filter?: boolean;
-							} = {
+							const dispatchSpec: TransactionSpec = {
 								changes: cmChanges,
 								annotations: [ySyncAnnotation.of(this.view)],
 							};
@@ -263,11 +255,7 @@ export class CM6Integration {
 				`setEditorText: replacing ${currentText.length} chars with ${text.length} chars`,
 			);
 			const replacementChanges = [{ from: 0, to: currentText.length, insert: text }];
-			const dispatchSpec: {
-				changes: { from: number; to: number; insert: string }[];
-				annotations: unknown[];
-				filter?: boolean;
-			} = {
+			const dispatchSpec: TransactionSpec = {
 				changes,
 				annotations: [ySyncAnnotation.of(this.view)],
 			};
@@ -285,11 +273,7 @@ export class CM6Integration {
 				requestAnimationFrame(() => {
 					if (!this.destroyed && this.isEditorStillValid()) {
 						const replacementChanges = [{ from: 0, to: currentText.length, insert: text }];
-						const dispatchSpec: {
-							changes: { from: number; to: number; insert: string }[];
-							annotations: unknown[];
-							filter?: boolean;
-						} = {
+						const dispatchSpec: TransactionSpec = {
 							changes,
 							annotations: [ySyncAnnotation.of(this.view)],
 						};

--- a/src/merge-hsm/testing/createTestHSM.ts
+++ b/src/merge-hsm/testing/createTestHSM.ts
@@ -113,6 +113,9 @@ export interface TestHSM {
   /** Wait for any pending idle auto-merge to complete */
   awaitIdleAutoMerge(): Promise<void>;
 
+  /** Seed or refresh the active editor buffer tracked by the HSM. */
+  bootstrapEditorView(viewId: string, currentText?: string): void;
+
   /** Directly set the provider synced state without triggering a state transition */
   setProviderSynced(value: boolean): void;
 

--- a/src/merge-hsm/testing/events.ts
+++ b/src/merge-hsm/testing/events.ts
@@ -710,7 +710,7 @@ export async function loadToConflict(
     data: opts.disk,
     clear: true,
   });
-  hsm.send(acquireLock(mockEditorViewRef(opts.disk)));
+  hsm.send(acquireLock(liveMockEditorViewRef(hsm, opts.disk)));
   // Wait for persistence to sync and state to settle
   await hsm.hsm?.awaitState?.((s) => !s.includes('awaitingPersistence') && !s.includes('entering'));
 


### PR DESCRIPTION
## Summary

- Fixes the current `merge-hsm` TypeScript build break by typing CodeMirror dispatch specs as `TransactionSpec`, relaxing awareness host typing to the `containerEl` surface it actually uses, and exposing the existing `bootstrapEditorView` helper on `TestHSM`.
- Fixes the failing `recalculate-conflict-positions` unit by making `loadToConflict()` use a live editor ref and by reading the editor buffer before applying `RESOLVE` content to `localDoc`.
- Does not broaden or revert `RelayDebugAPI` / debug API shape.

## Verification

- `git diff --check`
- `npm run build`
- `npm test -- --runTestsByPath __tests__/merge-hsm/MergeHSM.test.ts __tests__/merge-hsm/recalculate-conflict-positions.test.ts --runInBand`
- `npm test -- --runInBand`

QA reran the same gate and passed:

- targeted MergeHSM/recalculate: `2` suites / `200` tests
- full Jest: `36` suites / `795` tests

## Notes

This clears the product build/unit gate so the standard-suite UI/e2e failures can be interpreted downstream. It does not claim standard-suite UI/e2e coverage.
