### PR TITLE
ci: remove obsolete binary-free standard selector

### DIFF
--- a/.github/workflows/e2e-standard.yml
+++ b/.github/workflows/e2e-standard.yml
@@ -41,7 +41,7 @@ jobs:
             tests: test-share-folder,test-in-note-status
           - name: sync-state
             slug: sync-state
-            tests: test-idle-registration,test-active-editor-sync,test-offline-banner,test-binary-free-user
+            tests: test-idle-registration,test-active-editor-sync,test-offline-banner
           - name: conflicts-differ
             slug: conflicts-differ
             tests: test-differ-resolve,test-trigger-differ,test-differ-dismissal


### PR DESCRIPTION
## Summary
- remove `test-binary-free-user` from the active `sync-state` standard-suite shard
- keep the cleanup limited to selector membership only

## Boundaries
- workflow/test-infra selector change only
- no product source changes
- no debug API changes
- no Dan Python reference changes
- no Playwright file deletion or replacement test design

## Verification
- `git diff --check --`
- removed-selector grep confirms `test-binary-free-user` is absent from the edited workflow selector strings
- QA-reviewed packet recorded 18 workflow-selected names, 18 accepted harness selectors, 0 unknown selectors

## Merge-order note
This workflow removal is safe before the harness selector-map cleanup because the harness still accepts a superset of selected names. Do not merge the harness-side selector removal ahead of this workflow removal.
