### PR TITLE
ci(e2e): retire differ-dismissal selector

### DIFF
--- a/.github/workflows/e2e-standard.yml
+++ b/.github/workflows/e2e-standard.yml
@@ -44,7 +44,7 @@ jobs:
             tests: test-idle-registration,test-active-editor-sync,test-offline-banner
           - name: conflicts-differ
             slug: conflicts-differ
-            tests: test-differ-resolve,test-trigger-differ,test-differ-dismissal
+            tests: test-differ-resolve,test-trigger-differ
           - name: conflicts-resolution
             slug: conflicts-resolution
             tests: test-conflict-dismiss,test-conflict-cancel,test-upgrade-no-lca-conflict


### PR DESCRIPTION
## Summary
- Remove `test-differ-dismissal` from the `conflicts-differ` shard in `.github/workflows/e2e-standard.yml`.
- Leave `test-conflict-dismiss` selected in `conflicts-resolution` as the TP-020 keeper path.
- This is Phase 1 of the approved workflow-first retirement plan; harness expected-fail accounting remains unchanged until this workflow PR lands.

## Verification
- git diff --check --
- One-file diff: `.github/workflows/e2e-standard.yml` only.
- Static workflow-to-current-harness selector proof: 17 selected names, 17 unique, 18 accepted harness selectors, 0 unknown, 0 duplicates.
- `test-differ-dismissal` absent from workflow selector strings; still accepted by harness until Phase 2.
- `test-conflict-dismiss` remains selected.
- Shard arity proof: `conflicts-differ=1`, `conflicts-resolution=2`.

## Boundaries
No product/debug API edit, no Dan Python reference edit, no harness edit in this PR, no Playwright test deletion, no runner topology change, no TP-022 work, and no full standard-suite green claim.

Per Relay plugin boundary, agents should not merge this PR. Dan merges by default, or Matt must explicitly approve a direct merge in-pane.