### PR TITLE
Fix NOT_SYNCED pill clickability in folder nav

### DIFF
--- a/src/components/TextPill.svelte
+++ b/src/components/TextPill.svelte
@@ -1,14 +1,36 @@
 <script lang="ts">
 	export let text: string;
 	export let label: string;
+	export let onClick: (() => void) | undefined = undefined;
 </script>
 
-<div class="nav-file-tag system3-filepill" aria-label={label}>
-	<span>{text}</span>
-</div>
+{#if onClick}
+	<button
+		type="button"
+		class="nav-file-tag system3-filepill"
+		aria-label={label}
+		on:click={onClick}
+	>
+		<span>{text}</span>
+	</button>
+{:else}
+	<div class="nav-file-tag system3-filepill" aria-label={label}>
+		<span>{text}</span>
+	</div>
+{/if}
 
 <style>
 	.system3-filepill {
 		text-wrap: nowrap;
+	}
+
+	button.system3-filepill {
+		cursor: pointer;
+		background: none;
+		border: none;
+		padding: 0;
+		color: inherit;
+		font: inherit;
+		appearance: none;
 	}
 </style>

--- a/src/components/TextPill.svelte
+++ b/src/components/TextPill.svelte
@@ -2,6 +2,8 @@
 	export let text: string;
 	export let label: string;
 	export let onClick: (() => void) | undefined = undefined;
+
+	function swallowEvent() {}
 </script>
 
 {#if onClick}
@@ -9,7 +11,8 @@
 		type="button"
 		class="nav-file-tag system3-filepill"
 		aria-label={label}
-		on:click={onClick}
+		on:mousedown|stopPropagation={swallowEvent}
+		on:click|stopPropagation|preventDefault={onClick}
 	>
 		<span>{text}</span>
 	</button>

--- a/src/main.ts
+++ b/src/main.ts
@@ -1027,6 +1027,7 @@ export default class Live extends Plugin {
 			this.app.workspace,
 			this.sharedFolders,
 			this.backgroundSync,
+			(path) => this.openSettings(path),
 		);
 		this.folderNavDecorations.refresh();
 

--- a/src/ui/FolderNav.ts
+++ b/src/ui/FolderNav.ts
@@ -437,6 +437,7 @@ class NotSyncedPillDecoration {
 	constructor(
 		private el: HTMLElement,
 		label: string,
+		onClick: () => void,
 	) {
 		this.el.querySelectorAll(".system3-filepill").forEach((el) => {
 			el.remove();
@@ -447,6 +448,7 @@ class NotSyncedPillDecoration {
 			props: {
 				text: "NOT SYNCED",
 				label,
+				onClick,
 			},
 		});
 	}
@@ -464,6 +466,12 @@ class NotSyncedPillDecoration {
 }
 
 class NotSyncedPillVisitor extends BaseVisitor<NotSyncedPillDecoration> {
+	constructor(
+		private openSettings: (path: string) => Promise<void> | void,
+	) {
+		super();
+	}
+
 	visitFile(
 		file: TFile,
 		item: FileItem,
@@ -483,7 +491,9 @@ class NotSyncedPillVisitor extends BaseVisitor<NotSyncedPillDecoration> {
 				storage.setLabel(label);
 				return storage;
 			}
-			return new NotSyncedPillDecoration(item.selfEl, label);
+			return new NotSyncedPillDecoration(item.selfEl, label, () => {
+				void this.openSettings(`/shared-folders?id=${sharedFolder.guid}`);
+			});
 		}
 		if (storage) {
 			storage.destroy();
@@ -756,6 +766,7 @@ export class FolderNavigationDecorations {
 	workspace: Workspace;
 	sharedFolders: SharedFolders;
 	backgroundSync: BackgroundSync;
+	openSettings: (path: string) => Promise<void> | void;
 	offLayoutChange: () => void;
 	treeState: Map<WorkspaceLeaf, FileExplorerWalker>;
 	layoutReady: boolean = false;
@@ -799,11 +810,13 @@ export class FolderNavigationDecorations {
 		workspace: Workspace,
 		sharedFolders: SharedFolders,
 		backgroundSync: BackgroundSync,
+		openSettings: (path: string) => Promise<void> | void,
 	) {
 		this.vault = vault;
 		this.workspace = workspace;
 		this.sharedFolders = sharedFolders;
 		this.backgroundSync = backgroundSync;
+		this.openSettings = openSettings;
 		this.treeState = new Map<WorkspaceLeaf, FileExplorerWalker>();
 		this.workspace.onLayoutReady(() => {
 			this.layoutReady = true;
@@ -891,7 +904,7 @@ export class FolderNavigationDecorations {
 			);
 		});
 		visitors.push(new FilePillVisitor());
-		visitors.push(new NotSyncedPillVisitor());
+		visitors.push(new NotSyncedPillVisitor(this.openSettings));
 		visitors.push(new FileConflictVisitor());
 		return visitors;
 	}


### PR DESCRIPTION
## Summary

- make the `NOT SYNCED` pill interactive only for the blocked binary-file case
- thread the existing `openSettings(path)` entrypoint into the FolderNav NOT_SYNCED visitor path
- stop pill click propagation so the file row does not open instead of Relay settings

## Scope

- product-only Relay plugin fix
- branch is exactly two commits over `origin/merge-hsm`:
  - `ed171df58ecfe5ac619ea66859f0998bd57ae4b7` `Fix NOT_SYNCED pill clickability`
  - `9f6090059811d938892427b76743aa07e8ee8d91` `Stop NOT_SYNCED pill click propagation`
- files changed:
  - `src/components/TextPill.svelte`
  - `src/main.ts`
  - `src/ui/FolderNav.ts`

## Evidence

### RC4 current-product failure

- plugin: `e2fd1d5c9696ea8f332c5d40f1fbc914e9f1032e`
- harness: `eb657030d482c261a4aa346ce454f4c4f15a4b58`
- artifact root: `/private/tmp/relay-artifacts-rc4-binary-free-user-20260428T133827`
- result: `product_defect`
- failing assertion: `Surface: pill is clickable`
  - expected `cursor: pointer`
  - actual `cursor: default`

### First fix-branch rerun

- plugin: `ed171df58ecfe5ac619ea66859f0998bd57ae4b7`
- harness: `eb657030d482c261a4aa346ce454f4c4f15a4b58`
- artifact root: `/private/tmp/relay-artifacts-fix-binary-free-user-20260428T134808`
- result: partial forward movement
- clickable assertion passed
- new failing assertion: `Surface: pill click opens Relay settings`
  - expected Relay tab active with `Buy storage` visible
  - actual `Tab undefined`, `BuyStorage false`
- QA likely cause: pill click propagated to the parent file row and opened the file instead of Relay settings

### Final pass packet

- plugin: `9f6090059811d938892427b76743aa07e8ee8d91`
- harness: `eb657030d482c261a4aa346ce454f4c4f15a4b58`
- artifact root: `/private/tmp/relay-artifacts-fix2-binary-free-user-20260428T140108`
- exits all `0`, including `test_exit=0`
- aggregate success `pass=1 fail=0`
- child result `passed=true`, `status=pass`, `totalAssertions=9`, `passedAssertions=9`
- required assertions passed:
  - pill clickable
  - pill click opens Relay settings
  - binary toggles `OFF` / `LOCKED`
  - upgrade CTA visible

## QA

- QA Gate 2 verdict on the second follow-up packet: `ACCEPT/PASS`

## Validation

- clean worktree: `/private/tmp/relay-plugin-not-synced-fix-20260428-NS8bXi`
- `npm ci` passed
- `npm run build` passed

## Review / merge note

- Dan review requested
- agents must not merge this product PR
