### PR TITLE
fix: detach harness checkout in e2e standard workflow

### DIFF
--- a/.github/workflows/e2e-standard.yml
+++ b/.github/workflows/e2e-standard.yml
@@ -320,9 +320,10 @@ jobs:
             git clone git@github.com:No-Instructions/relay-harness.git ~/relay-harness
           fi
           cd ~/relay-harness
-          git fetch origin
-          git checkout main
-          git pull
+          git fetch origin --prune
+          git checkout -- .
+          git clean -fd
+          git checkout --detach origin/main
 
           # Clear stale repo-local test instances left by canceled or crashed runs
           echo "Clearing stale repo-local slots..."


### PR DESCRIPTION
## Summary

This is a workflow-only fix for the standard e2e runner. It does not change Relay product source.

The persistent VM runner was updating `~/relay-harness` with:

```bash
git fetch origin
git checkout main
git pull
```

Recent standard-suite runs reach the VM remote script, then fail on this block with:

```text
Your branch and 'origin/main' have diverged
exit code 128
```

This PR makes the harness checkout deterministic each run:

```bash
git fetch origin --prune
git checkout -- .
git clean -fd
git checkout --detach origin/main
```

That mirrors the workflow's existing plugin checkout posture and removes dependence on the VM's stale local `main` branch state.

## Verification

- `git diff --check`
- Ruby YAML parse of `.github/workflows/e2e-standard.yml`
- QA reviewed the workflow-only diff and accepted it for the reported persistent-VM divergence failure mode

## Notes

This specifically fixes branch/worktree drift in the persistent `~/relay-harness` checkout. If a VM is ever left in a more pathological Git state, such as an in-progress merge or rebase, that remains a separate VM recovery case.
