### PR TITLE
ci: run standard suite for rc tags

### DIFF
--- a/.github/workflows/e2e-standard.yml
+++ b/.github/workflows/e2e-standard.yml
@@ -3,6 +3,8 @@ name: E2E standard suite
 on:
   push:
     branches: [merge-hsm]
+    tags:
+      - '0.8.0-rc*'
   workflow_dispatch:
     inputs:
       ref:
@@ -252,7 +254,18 @@ jobs:
       - name: Run standard suite on VM
         if: steps.select-tests.outputs.should_run == 'true'
         run: |
-          REF="${{ github.event.inputs.ref || format('origin/{0}', github.ref_name) }}"
+          INPUT_REF="${{ github.event.inputs.ref || '' }}"
+          REF_TYPE="${{ github.ref_type }}"
+          REF_NAME="${{ github.ref_name }}"
+
+          if [ -n "$INPUT_REF" ]; then
+            REF="$INPUT_REF"
+          elif [ "$REF_TYPE" = "tag" ]; then
+            REF="refs/tags/$REF_NAME"
+          else
+            REF="origin/$REF_NAME"
+          fi
+
           SELECTED_TESTS="${{ steps.select-tests.outputs.selected_tests }}"
           SHARD_SLUG_ARG="${{ matrix.shard.slug }}"
 
@@ -309,11 +322,16 @@ jobs:
             git clone https://github.com/No-Instructions/Relay.git ~/relay-plugin
           fi
           cd ~/relay-plugin
-          git fetch --all --prune
+          git fetch origin --force --prune \
+            '+refs/heads/*:refs/remotes/origin/*' \
+            '+refs/tags/*:refs/tags/*'
           git checkout -- .
           git clean -fd
           # Detached HEAD checkout — works for origin/branch, tags, and SHAs
           git checkout --detach "$REF"
+          echo "Relay product checkout:"
+          git show -s --format='  commit: %H%n  subject: %s'
+          echo "  describe: $(git describe --tags --always --long 2>/dev/null || git rev-parse --short HEAD)"
 
           # Clone or update relay-harness (private)
           if [ ! -d ~/relay-harness ]; then

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -179,7 +179,8 @@ const watchAndMove = (fnames, mapping) => {
 
 const mapping = debug ? { "manifest-beta.json": "manifest.json" } : {};
 const manifest = debug ? "manifest-beta.json" : "manifest.json";
-const files = (debug && out === ".") ? ["styles.css"] : ["styles.css", manifest];
+const shouldWriteManifest = !develop;
+const files = (!shouldWriteManifest && out === ".") ? ["styles.css"] : ["styles.css", manifest];
 
 const updateManifest = (manifest) => {
 	const manifestPath = path.join(out, path.basename("manifest.json"));
@@ -204,14 +205,14 @@ const move = (fnames, mapping) => {
 if (watch) {
 	await context.watch();
 	move(files, mapping);
-	if (!develop) {
+	if (shouldWriteManifest) {
 		updateManifest();
 	}
 	watchAndMove(files, mapping);
 } else {
 	await context.rebuild();
 	move(files, mapping);
-	if (!develop && out !== ".") {
+	if (shouldWriteManifest) {
 		updateManifest();
 	}
 	process.exit(0);


### PR DESCRIPTION
## Summary
- trigger the standard E2E workflow for RC tags
- fetch tags on VMs and checkout exact tag refs correctly
- stamp non-develop release/beta manifests from `git describe --tags --always` so tag builds do not carry stale source `manifest.json.version`

## Verification
- `node --check esbuild.config.mjs`
- `git diff --check`
- existing branch verification for workflow patch: actionlint, YAML parse, ref-resolution simulation

## Context
RC9 ran the intended git commit/tag, but the test vault loaded a plugin manifest with stale version `0.7.4`. This keeps the workflow automation and build artifact metadata aligned for future RC runs.
