### PR TITLE
ci: refresh report-site target summaries

### DIFF
--- a/.github/workflows/e2e-standard.yml
+++ b/.github/workflows/e2e-standard.yml
@@ -301,6 +301,7 @@ jobs:
 
           # Clean stale test reports from previous runs
           rm -rf /tmp/test-reports
+          rm -f ~/test-summary.json ~/test-metadata.json
 
           # Activate GCP service account for gcloud/GCS uploads
           gcloud auth activate-service-account --key-file="$HOME/ci-sa-key.json" 2>/dev/null
@@ -393,6 +394,7 @@ jobs:
       - name: Fetch results
         if: always() && steps.select-tests.outputs.should_run == 'true'
         run: |
+          rm -f summary.json metadata.json
           gcloud compute scp --quiet "$VM_NAME":~/test-summary.json ./summary.json \
             --zone="$VM_ZONE" --project="$GCP_PROJECT" \
             --tunnel-through-iap 2>/dev/null || true
@@ -650,6 +652,7 @@ jobs:
 
           node scripts/publish-report-site-static.mjs \
             --commit="$COMMIT_SET" \
+            --refresh-commit="$TARGET_COMMIT" \
             --materialize-missing-commits \
             --rebuild-manifest-from-commits \
             --upload \


### PR DESCRIPTION
## Summary
- clear stale VM home result files before each standard-suite remote run
- clear local runner `summary.json` / `metadata.json` before fetching VM results
- pass `--refresh-commit=$TARGET_COMMIT` to the report-site publisher so reruns of an existing commit update the commit summary/sidebar instead of reusing stale metadata

## Verification
- actionlint with shellcheck disabled for `.github/workflows/e2e-standard.yml`
- Ruby YAML parse
- `git diff --check`

## Context
The exact RC9 rerun checked out `0.8.0-rc9` and installed test vaults with manifest version `0.8.0-rc9`, but the automatic publisher reused the old `runs/8d2f5bf/summary.json` because the commit already existed. This patch closes that rerun path.
