### PR TITLE
Support self-hosted relay management routes

### DIFF
--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -37,8 +37,8 @@ const positionalArgs = process.argv.slice(3).filter((a) => !a.startsWith("--"));
 const out = positionalArgs[0] || ".";
 const tld = staging ? "dev" : "md";
 
-const apiUrl = `https://api.system3.${tld}`;
-const authUrl = `https://auth.system3.${tld}`;
+const apiUrl = process.env.RELAY_API_URL || `https://api.system3.${tld}`;
+const authUrl = process.env.RELAY_AUTH_URL || `https://auth.system3.${tld}`;
 const healthUrl = `${apiUrl}/health?version=${gitTag}`;
 console.log("git tag:", gitTag);
 console.log("health URL", healthUrl);

--- a/src/RelayManager.ts
+++ b/src/RelayManager.ts
@@ -1675,7 +1675,7 @@ export class RelayManager extends HasLogging {
 			throw new Error("missing pocketbase");
 		}
 		return this.pb
-			.send("/api/rotate-key", {
+			.send("/api/self-host-rotate-key", {
 				method: "POST",
 				headers: {
 					"Content-Type": "application/json",

--- a/src/components/ManageRelay.svelte
+++ b/src/components/ManageRelay.svelte
@@ -196,7 +196,7 @@
 			// Use customFetch directly since PocketBase's .send() tries to parse as JSON
 			const fullUrl =
 				plugin.relayManager.pb.baseUrl +
-				`/api/collections/relays/records/${relay.id}/relay.toml`;
+				`/api/self-host-relay-toml/${relay.id}`;
 			const response = await customFetch(fullUrl, {
 				method: "GET",
 				headers: {


### PR DESCRIPTION
## Summary
- allow local/self-hosted builds to override relay API and auth endpoints via RELAY_API_URL and RELAY_AUTH_URL
- route self-hosted relay key rotation through /api/self-host-rotate-key
- fetch generated self-host relay.toml through /api/self-host-relay-toml/:id

## Validation
- built plugin with RELAY_API_URL=http://localhost:3000 and RELAY_AUTH_URL=http://localhost:8090
- sideloaded the rebuilt plugin into two git-backed Obsidian vault clones
- connected both Obsidian 1.12.7 renderers to the same local self-hosted relay and shared folder
- created Shared/Live-1782801629622.md in Vault A and observed identical content in Vault B via the live relay