### PR TITLE
fix: refuse to bind fragment editors to the document HSM

### DIFF
--- a/src/merge-hsm/integration/HSMEditorPlugin.ts
+++ b/src/merge-hsm/integration/HSMEditorPlugin.ts
@@ -261,6 +261,23 @@ export class HSMEditorPluginValue implements PluginValue {
     if (this.cm6Integration) return true;
     if (this.destroyed) return false;
 
+    // Never bind a fragment editor. Obsidian creates child EditorViews
+    // scoped to a fragment of the document (e.g. live-preview table cell
+    // editors); they resolve editorInfoField.file to the host file, so every
+    // identity check below passes, but their buffer holds only the fragment.
+    // Binding one treats fragment content and offsets as whole-document
+    // state: the born-attached render replaces the fragment with the full
+    // document text, and CM6_CHANGE events apply fragment-relative positions
+    // to the document Y.Text. A fragment editor is recognizable because the
+    // info field's `editor` is the host view's main editor, not itself. (DOM
+    // ancestry cannot be used here: fragment editors are created detached,
+    // so their DOM is not yet inside the host editor at bind time.)
+    // Fragment edits reach the document through the host editor when the
+    // widget commits them.
+    const bindingInfo = this.editor.state.field(editorInfoField, false);
+    const infoEditorView = (bindingInfo?.editor as { cm?: EditorView } | undefined)?.cm;
+    if (infoEditorView && infoEditorView !== this.editor) return false;
+
     const connectionManager = getConnectionManager(this.editor);
     if (!connectionManager) return false;
 


### PR DESCRIPTION
🍋: drafted by an AI assistant working with @petergaultney

On 0.8.8, clicking a table cell in live preview on a synced note can replace that cell's content with the entire document. The cause is the born-attached binding from f3522c0f: it cannot tell a whole-document editor from one of Obsidian's table-cell child editors, so it binds the cell editor to the document HSM and renders the full document text into it. This PR refuses to bind such fragment editors. Their edits already reach the document through the host editor, so nothing else changes.

Technical details follow.

## Symptom

Clicking a table cell in live preview on a synced markdown note replaces the cell's content with the entire document text, `<br>`-escaped. Obsidian's table formatter then pads every row to the new column width; a few-KB note grows to hundreds of KB in one click. It reproduces every time - a markdown table of a few lines in any synced note is enough. We saw three field occurrences and ran three controlled reproductions on our vault today.

## Mechanism

Obsidian's live-preview table editing creates a child CM6 EditorView per cell being edited. That child editor receives globally registered editor extensions, including `HSMEditorPlugin`. Its `editorInfoField.file` resolves to the host file, so every identity check in `initializeIfReady` passes and the cell editor binds to the document's HSM as if it were a whole-document view:

1. `probeBornAttached()` returns true. The document is already `active.tracking` under the host view, and the cell editor is not a canvas embed (`mod-inside-iframe`), the only nested case currently excluded.
2. `renderBornAttached()` replaces "whatever the buffer holds" with the document text: `{from: 0, to: cellText.length, insert: entireDocument}`.
3. The table widget commits the child editor's buffer back into the cell, escaping newlines to `<br>`.

There is a second corruption vector from the same root: once a fragment editor is bound, its keystrokes are forwarded as `CM6_CHANGE` with cell-relative offsets, which the HSM applies to the whole document's Y.Text.

Introduced by f3522c0f ("fix: bind subsequent editor views to active documents"). Before that, nested editors never completed binding because no LiveView adopted them. 0.8.7 is unaffected.

## Fix

Refuse to bind any editor whose `editorInfoField.editor.cm` is not the editor itself. For a fragment editor, that resolves to the host view's main editor. Fragment edits still reach the document exactly as they did before f3522c0f: the host editor's binding receives them when the widget commits the cell back into the host document.

We tried DOM ancestry first (`editor.dom.parentElement?.closest(".cm-editor")`) and it does not work. Live instrumentation of a bound cell editor showed `dom.isConnected === false` at the moment `initializeIfReady` passes its other guards: fragment editors are created detached and attached to the widget DOM later, so DOM ancestry is invisible at bind time.

Bind-time traces from the instrumented plugin (wrapping `initializeIfReady` via CDP on a live vault):

```
cell editor:  docLen=4,    domConnected=false, infoFile=<host file>, info.editor.cm === self: false
main editor:  docLen=1268, domConnected=true,  infoFile=<own file>,  info.editor.cm === self: true
```

The guard applies only when `editorInfoField.editor` exists and differs from the bound editor. Editors whose info field has no `editor` (canvas embeds during setup, views where `editorInfoField` lags) fall through to the existing checks unchanged.

## Testing

- `tsc -noEmit` clean.
- The guard was validated by hot-patching it into a running 0.8.8 install. Before the patch, the scripted reproduction corrupted the note every time (65 chars -> 494). With the guard, the cell editor is refused, the note stays intact, and typed text appears at the correct position and syncs through the host editor to disk and the relay server.
- Canvas: with the guard installed, canvas text-node and file-node editing both work and sync. Instrumentation shows a canvas file-node editor's `editorInfoField.editor.cm` is itself, so the guard does not affect embed editors.
