### PR TITLE
chore: log identity mints, shadowed upload holds, and legacy meta re-creation

### DIFF
--- a/src/SyncStore.ts
+++ b/src/SyncStore.ts
@@ -207,6 +207,7 @@ export class SyncStore extends Observable<SyncStore> {
 		this.assertVPath(vpath);
 		const guid = uuidv4();
 		this.pendingUpload.set(vpath, guid);
+		this.log("minted identity", vpath, guid);
 		return guid;
 	}
 
@@ -329,6 +330,13 @@ export class SyncStore extends Observable<SyncStore> {
 			const pendingGuid = this.pendingUpload.get(vpath);
 			if (pendingGuid && pendingGuid === meta.id) {
 				this.pendingUpload.delete(vpath);
+			} else if (pendingGuid) {
+				// The pending-upload hold is now stale; if nothing clears it,
+				// the path re-publishes when this committed entry is deleted.
+				this.warn("committed claim shadows a pending-upload hold", vpath, {
+					pending: pendingGuid,
+					committed: meta.id,
+				});
 			}
 		});
 	}
@@ -540,6 +548,11 @@ export class SyncStore extends Observable<SyncStore> {
 
 		if (!meta && this.legacyIds.has(vpath)) {
 			const guid = this.legacyIds.get(vpath)!;
+			this.warn(
+				"meta missing but legacy docs entry remains; scheduling meta re-creation",
+				vpath,
+				guid,
+			);
 			const newMeta = makeDocumentMeta(guid);
 			this.overlay.set(vpath, newMeta);
 			return newMeta;


### PR DESCRIPTION
🍋: drafted by an AI assistant working with @petergaultney

We spent this week chasing "zombie files" (deleted files that reappear) across a ~40-user fleet, and the hardest part was that the identity lifecycle leaves no trace: mints are silent, a lost claim race leaks its pending-upload hold silently, and legacy-map meta re-creation is silent. This PR adds one log line at each of those moments. No behavior changes.

Technical details follow.

## The three log points

1. `SyncStore.new()` logs each minted guid with its vpath. When a deleted file comes back under a fresh guid, this line is the only way to find which client minted it and when.
2. `SyncStore.set()` warns when committed metadata lands over a pending-upload hold carrying a different guid. This is the moment a lost claim race strands its hold; stranded holds are what later re-publish deleted paths (see #115 for the mechanism and a proposed mitigation).
3. `SyncStore.getMeta()` warns when it schedules meta re-creation from a lingering legacy `docs` entry - the meta-without-legacy convergence path already runs silently in the other direction, and this is the one that resurrects.

## Field context

On one long-lived vault we found 82 stranded pending-upload holds dating back months, discovered only by manually dumping localStorage. With these lines, the moment of each leak would have been in the log with a path and both guids.

## Testing

- `tsc -noEmit` clean.
- These lines are included in an internal hotfix build that runs on a **single vault (the author's) - no other users are running this change**.
- The mint line has been observed live: creating a note logged `minted identity /z-meta/testing-and-debugging/zombie-f-teardown-test.md 64545b1e-...` in the plugin's debug log.
- The other two lines have not fired on that vault yet: the shadowed-hold warn requires losing a fresh claim race (the ~80 pre-existing stale holds on this vault were found by inspecting localStorage directly, before this logging existed), and the legacy re-creation warn requires a legacy-only write from an old client.
