### PR TITLE
fix: tear down the live doc when adopting a remote deletion

### DIFF
--- a/src/SharedFolder.ts
+++ b/src/SharedFolder.ts
@@ -2533,9 +2533,26 @@ export class SharedFolder extends HasProvider {
 				if (synced) {
 					diffLog.push(`deleted local file ${vpath} for remotely deleted doc`);
 					this.markPendingDelete(vpath);
-					const promise = this.vault.adapter.trashLocal(file.path).finally(() => {
-						this.clearPendingDelete(vpath);
-					});
+					const promise = this.vault.adapter
+						.trashLocal(file.path)
+						.then(() => {
+							// The suppressed delete echo leaves the live doc in
+							// place, and a surviving doc's next engine write
+							// re-creates the file (createIfMissing) and re-mints
+							// it as a new identity. Tear it down the way a
+							// processed vault delete would.
+							const doc = this.fset.find((f) => f.path === vpath);
+							if (doc) {
+								this.fset.delete(doc);
+								this.files.delete(doc.guid);
+								doc.cleanup();
+								doc.destroy();
+								this.teardownDocState(doc.guid);
+							}
+						})
+						.finally(() => {
+							this.clearPendingDelete(vpath);
+						});
 					deletes.push({
 						op: "delete",
 						path: vpath,


### PR DESCRIPTION
🍋: drafted by an AI assistant working with @petergaultney

When a remote deletion arrives, `cleanupExtraLocalFiles` trashes the local disk file - but the live `Document` survives, because `markPendingDelete` suppresses the trash's vault-delete echo, and nothing else destroys it. A surviving doc's next engine write runs `writeDiskContents` with `createIfMissing: true`, re-creating the file at the deleted path; the reappeared file then registers as a brand-new doc and republishes to every client. The fix destroys the doc after the trash completes, exactly the teardown a processed vault delete performs.

Technical details follow.

## Mechanism

1. Client A deletes a file; the meta-map removal syncs to client B, which has the doc open (or warm).
2. B's `cleanupExtraLocalFiles` marks the path pending-delete and calls `adapter.trashLocal`. The pending-delete mark suppresses the resulting vault-delete event, so `deleteFiles` (which would have destroyed the doc) never runs for it.
3. B's doc lives on with its HSM and provider connection. Its next disk write finds no tfile and takes the `vault.create` branch (`createIfMissing`), re-creating the file.
4. The new-file registration path mints a fresh guid for it 500ms later and uploads - the deleted file returns for everyone, under a new identity.

Whether step 2's suppression works is a race between the trash promise's `finally` (which clears the mark) and the vault event's dispatch: in our testing the event often escaped suppression and destroyed the doc "by luck", which is why this only bites sometimes. Field signature: a moved/deleted file whose old path returns seconds later as a new file, but only when some client had it open - we observed one of two files moved in the same commit resurrect while its sibling stayed gone.

## Fix

After `trashLocal` resolves, find the live doc at that vpath and run the same teardown `deleteFiles` performs (fset/files removal, `cleanup()`, `destroy()`, per-doc IDB/HSM state removal). The convergence-hold deletion path (`applyPendingUpload`'s remote-deleted-hold adoption) already destroys the live doc this way; this brings the ordinary cleanup path to parity.

## Testing

- `tsc -noEmit` clean.
- The fix is in an internal hotfix build running on a **single vault (the author's) - no other users are running this change**.
- Pre-fix mechanism evidence (stock 0.8.8, same vault): we simulated a peer's deletion of a note that was open in a tab with unsaved edits, by removing the path's entries from the folder's shared metadata maps in a transaction with a non-local origin - the plugin processes this exactly like a remote deletion. Method-level logging in the running plugin showed `cleanupExtraLocalFiles` trashing the file, and the vault-delete echo escaping the `markPendingDelete` suppression by ~24ms and running `deleteFiles`. In other words, the doc was destroyed only because the suppression *lost* its race; whether a doc survives a remote delete (and can later rewrite the file) is timing-dependent.
- Post-fix (same procedure, 2026-08-06): file trashed, meta stayed deleted, the live doc was removed from the folder's file set, and no re-registration or new-guid mint occurred over the following minute despite the open, dirty editor. The echo also fired in this run; the added teardown is idempotent alongside it and makes the outcome deterministic instead of race-dependent.
- Not yet reproduced end-to-end: the motivating field pattern (a moved file's old path returning ~12s later as a new file, only when some client had it open) requires a second client; we plan a two-client test setup for that.
