### PR TITLE
fix: sweep stale pending-upload holds after converged tree syncs

### DIFF
--- a/src/SharedFolder.ts
+++ b/src/SharedFolder.ts
@@ -2997,6 +2997,45 @@ export class SharedFolder extends HasProvider {
 		this.fset.update();
 	}
 
+	/**
+	 * A pending-upload hold whose path already has committed metadata is
+	 * finished business: a matching guid means publication completed and the
+	 * clear was missed; a different guid means the claim lost its race and
+	 * adoption has had its chance by the end of a converged sync. A leaked
+	 * hold is not inert - it shields the local file from remote-delete
+	 * cleanup and re-publishes the path on the first tree sync after its
+	 * committed meta is deleted (deleted files silently reappear) - and
+	 * localStorage preserves it across sessions indefinitely.
+	 */
+	private sweepStalePendingUploads(): void {
+		if (!(this._provider?.synced && this._persistence?.synced)) return;
+
+		const stale: {
+			vpath: string;
+			pending: string;
+			committed: string;
+			enrolledUnderPending: boolean;
+		}[] = [];
+		this.syncStore.pendingUpload.forEach((guid, vpath) => {
+			if (this._pendingRemaps.has(vpath)) return;
+			if (this._convergencePublicationRuns?.has(vpath)) return;
+			const committed = this.syncStore.getCommittedMeta(vpath);
+			if (!committed) return;
+			// A live instance under the losing guid means adoption stalled;
+			// clearing the hold lets the reconciliation sweep re-key it.
+			stale.push({
+				vpath,
+				pending: guid,
+				committed: committed.id,
+				enrolledUnderPending: !!this.files.get(guid),
+			});
+		});
+		if (stale.length === 0) return;
+
+		stale.forEach(({ vpath }) => this.pendingUpload.delete(vpath));
+		this.warn("dropped stale pending-upload holds", stale);
+	}
+
 	syncFileTree(): Promise<void> {
 		// If a sync is already running, mark that we want another sync after
 		if (this.syncFileTreePromise) {
@@ -3084,6 +3123,7 @@ export class SharedFolder extends HasProvider {
 				if (diffLog.length > 0) {
 					this.log("syncFileTree diff:\n" + diffLog.join("\n"));
 				}
+				this.sweepStalePendingUploads();
 			} finally {
 				// Reset the promise after completion (success or failure)
 				this.syncFileTreePromise = null;


### PR DESCRIPTION
🍋: drafted by an AI assistant working with @petergaultney

Deleted files kept coming back across our ~40-user fleet - several hundred resurrections in a month - and we traced the volume to stale pending-upload holds. A hold whose claim race was lost is supposed to be cleaned up during adoption, but for content-addressed files that cleanup can stall, and the hold then lives in localStorage forever. Every stale hold is armed: it shields the local file from remote-delete cleanup, and `applyPendingUpload` re-publishes the path on the first tree sync after its committed meta disappears - i.e. the moment anyone deletes the file. This PR sweeps holds whose path already has committed metadata, at the end of each converged tree sync, bounding a leaked hold's lifetime to one sync interval instead of forever.

Technical details follow.

## Evidence

On one long-lived vault we found **82 stale holds**, nearly all attachments and `.base` files, some dating back to 2025-09. Every one was in the same state: path committed under a different guid than the hold, and the local file still enrolled under the losing guid - i.e. adoption had stalled, not merely lagged.

Live demonstration of the arm: we simulated a remote deletion (meta-map removal) of one such path. The client re-published it from its stale hold **162ms later**; within the same second a *second* client somewhere in the fleet republished it from *its* stale hold and won the race - the "deleted" file came back under a third guid. Resurrected files are then re-downloaded fleet-wide, and the download race can strand fresh holds on other clients, so the population is self-sustaining.

`handleCompetingClaim` adopts-and-clears for Documents and Canvases but explicitly delegates content-addressed files to the reconciliation sweep ("identity adoption flows through the reconciliation sweep..."), whose hash-match preconditions can fail; nothing logs the stall and nothing bounds the hold's lifetime.

## Fix

At the end of each tree sync on a converged folder (`provider.synced && persistence.synced`), drop any pending-upload hold whose path has committed metadata:

- matching guid: publication completed, the clear was missed (SyncStore.set's early-return skips the clear when meta is unchanged);
- different guid: the claim lost; by the end of a converged sync, adoption has had its chance.

Paths with in-flight remaps or coordinated publication runs are skipped. Genuinely-new files (no committed meta) are untouched. Each sweep logs what it dropped, including whether a live instance was still enrolled under the losing guid.

This is a mitigation: the underlying stall in lost-claim adoption for content-addressed files still deserves a root-cause fix, and we'd welcome guidance on where that belongs. The sweep makes the failure bounded and visible in the meantime.

## Testing

- `tsc -noEmit` clean.
- The sweep is in an internal hotfix build running on a **single long-lived vault (the author's) - no other users are running this change**.
- Discovery (stock 0.8.8, same vault): enumerating the localStorage `pendingUploads` entries and cross-checking each against the folder's committed metadata found **83 stale holds** across two shared folders - every one committed under a different guid than the hold, every one with the local file still enrolled under the losing guid, many dating back months.
- Arm demonstration (pre-fix): removing one armed path's entries from the shared metadata maps in a non-local-origin transaction (processed exactly like a peer's deletion) caused this client to re-publish the path from its stale hold **162ms later** - method-level logging in the running plugin showed `applyPendingUpload` firing and `markUploaded` committing meta under the hold's guid. A second client elsewhere in the fleet, running stock Relay with its own stale hold for the same path, republished within the same second and won the race; the file came back under a third guid.
- Fix validation (2026-08-05): the first converged sync after install dropped all 82 remaining stale holds (one was consumed by the arm demonstration), each logged with its pending/committed guid pair; subsequent syncs drop nothing, and relay-doctor's pending-uploads count now reads 0 on this vault.
- Not yet verified: that deletions of previously-armed paths stay deleted fleet-wide. Other clients still run stock builds with their own stale holds, so the demonstration file is expected to keep resurrecting until a fix reaches them.
