### PR TITLE
fix: stop the frontmatter append loop (Y.Text/Y.Map mirror deadlock)

### DIFF
--- a/src/merge-hsm/MergeHSM.ts
+++ b/src/merge-hsm/MergeHSM.ts
@@ -6396,13 +6396,20 @@ export class MergeHSM implements MachineHSM, SyncBridgeHost {
 
 		const yamlBody = this._yaml.stringify(obj);
 		// Trailing `\n` on the canonical frontmatter is required so that
-		// concatenation with `text.slice(fm.end)` (which begins with the
+		// concatenation with the body slice (which begins with the
 		// blank-line `\n`) preserves the `\n\n` frontmatter-to-body
 		// separator. Omitting it drops the blank line on every Y.Map
 		// dispatch — the shape producing `---\nhello` on disk for
 		// live1/live2 butter.md after Properties toggles.
 		const frontmatter = `---\n${yamlBody}---\n`;
-		const body = fm ? text.slice(fm.end) : text;
+		// Slice from past any frontmatter debris (stray sibling blocks, or an
+		// unparseable first block) so the editor sees the same canonical form
+		// repairFrontmatterFromMap writes to the Y.Text — otherwise the buffer
+		// re-saves the debris to disk and the doc diverges into a conflict.
+		const info = this._yaml.getFrontMatterInfo(text);
+		const body = info.exists
+			? text.slice(this.frontmatterDebrisEnd(text, info.contentStart, ymap))
+			: text;
 
 		return frontmatter + body;
 	}
@@ -6452,13 +6459,6 @@ export class MergeHSM implements MachineHSM, SyncBridgeHost {
 
 		if (!fm) return; // Can't parse — don't touch the map
 
-		const parsedKeys = Object.keys(fm.parsed);
-
-		// Safety: if the parsed frontmatter has fewer keys than the Y.Map,
-		// the Y.Text is likely corrupted (e.g., double --- delimiters causing
-		// a truncated parse). Skip the sync to avoid destroying Y.Map data.
-		if (ymap.size > 0 && parsedKeys.length < ymap.size) return;
-
 		// Store each property value as a JSON string for faithful round-tripping.
 		// Y.Map uses LWW per key, so concurrent writes produce a clean winner.
 		for (const [key, value] of Object.entries(fm.parsed)) {
@@ -6467,11 +6467,50 @@ export class MergeHSM implements MachineHSM, SyncBridgeHost {
 				ymap.set(key, serialized);
 			}
 		}
-		// Only delete keys when the parsed frontmatter is plausibly complete
+		// A second `---` block immediately after the parsed one means the parse
+		// was likely truncated (double-delimiter corruption), so its key set is
+		// partial — don't treat the missing keys as deletions. A clean
+		// single-block parse is trusted in full, including key deletions;
+		// a count-based guard here mistakes ordinary deletions for corruption
+		// and leaves stale keys in the Y.Map forever (the armed state of the
+		// frontmatter append loop).
+		if (text.slice(fm.end).trimStart().startsWith("---")) return;
+
 		for (const key of [...ymap.keys()]) {
 			if (!(key in fm.parsed)) {
+				this.crdtLog(`pruning frontmatter key deleted from text: ${key}`);
 				ymap.delete(key);
 			}
+		}
+	}
+
+	/**
+	 * Find where frontmatter debris ends. Concurrent frontmatter rewrites can
+	 * CRDT-merge into stray sibling `---` blocks right after the real one;
+	 * this returns the offset past every such block so a repair can collapse
+	 * all of them. A block is only treated as debris when its interior parses
+	 * as a YAML mapping sharing a key with the Y.Map — a horizontal rule or
+	 * other legitimate body content is never consumed.
+	 */
+	private frontmatterDebrisEnd(
+		text: string,
+		contentStart: number,
+		ymap: Y.Map<unknown>,
+	): number {
+		let end = contentStart;
+		const blockRe = /^\s*---\r?\n([\s\S]*?)\r?\n---(\r?\n|$)/;
+		for (;;) {
+			const match = text.slice(end).match(blockRe);
+			if (!match) return end;
+			let parsed: unknown;
+			try {
+				parsed = this._yaml!.parse(match[1]);
+			} catch {
+				return end;
+			}
+			if (!parsed || typeof parsed !== "object") return end;
+			if (!Object.keys(parsed).some((key) => ymap.has(key))) return end;
+			end += match[0].length;
 		}
 	}
 
@@ -6479,6 +6518,11 @@ export class MergeHSM implements MachineHSM, SyncBridgeHost {
 	 * Detect frontmatter corruption by comparing Y.Text frontmatter against
 	 * Y.Map("frontmatter"). If mismatched, reconstruct from Y.Map and apply.
 	 * Called after merging remote updates into localDoc.
+	 *
+	 * Also the recovery path for frontmatter that no longer parses (duplicate
+	 * keys) or has grown stray sibling blocks — both states are produced by
+	 * concurrent repairs merging badly, and neither can heal through the
+	 * parse-dependent sync path.
 	 */
 	private repairFrontmatterFromMap(): void {
 		if (!this.localDoc || !this._yaml) return;
@@ -6492,9 +6536,11 @@ export class MergeHSM implements MachineHSM, SyncBridgeHost {
 		if (ymap.size === 0) return;
 
 		const text = this.localDoc.getText("contents").toString();
-		const fm = this.parseFrontmatter(text);
+		const info = this._yaml.getFrontMatterInfo(text);
+		if (!info.exists) return; // No frontmatter block to repair
 
-		if (!fm) return; // No frontmatter block to repair
+		const fm = this.parseFrontmatter(text);
+		const debrisEnd = this.frontmatterDebrisEnd(text, info.contentStart, ymap);
 
 		// Mirror Obsidian's processFrontMatter: start from the parsed
 		// frontmatter (preserves on-disk key order) and mutate in place
@@ -6502,8 +6548,9 @@ export class MergeHSM implements MachineHSM, SyncBridgeHost {
 		// Keys present in Y.Map but absent from the parsed frontmatter
 		// are appended. This keeps Obsidian's writes and our repairs
 		// emitting the same key order so DMP only sees content-level
-		// changes, never reorders.
-		const obj: Record<string, any> = { ...fm.parsed };
+		// changes, never reorders. When the block doesn't parse at all
+		// (duplicate keys), the Y.Map is the only readable truth.
+		const obj: Record<string, any> = fm ? { ...fm.parsed } : {};
 		for (const [key, value] of ymap.entries()) {
 			let parsed: any;
 			try { parsed = JSON.parse(value as string); }
@@ -6514,35 +6561,42 @@ export class MergeHSM implements MachineHSM, SyncBridgeHost {
 			if (!ymap.has(key)) delete obj[key];
 		}
 
-		// Corruption check: values differ, or the set of keys differs.
-		let corrupted = false;
-		const parsedKeys = Object.keys(fm.parsed);
-		const objKeys = Object.keys(obj);
-		if (parsedKeys.length !== objKeys.length) {
-			corrupted = true;
-		} else {
-			for (const key of objKeys) {
-				if (JSON.stringify(fm.parsed[key]) !== JSON.stringify(obj[key])) {
-					corrupted = true;
-					break;
+		// Corruption check: unparseable block, stray sibling blocks,
+		// differing values, or a differing key set.
+		let corrupted = !fm || debrisEnd > info.contentStart;
+		if (!corrupted) {
+			const parsedKeys = Object.keys(fm!.parsed);
+			const objKeys = Object.keys(obj);
+			if (parsedKeys.length !== objKeys.length) {
+				corrupted = true;
+			} else {
+				for (const key of objKeys) {
+					if (JSON.stringify(fm!.parsed[key]) !== JSON.stringify(obj[key])) {
+						corrupted = true;
+						break;
+					}
 				}
 			}
 		}
 
 		if (!corrupted) return;
 
-		this.crdtLog("frontmatter corruption detected — repairing from Y.Map");
+		this.crdtLog(
+			`frontmatter corruption detected — repairing from Y.Map ` +
+			`(parseable=${!!fm}, debris=${debrisEnd - info.contentStart}, ` +
+			`textKeys=[${fm ? Object.keys(fm.parsed) : ""}], mapKeys=[${[...ymap.keys()]}])`,
+		);
 
 		const yamlBody = this._yaml.stringify(obj);
 		// Obsidian's getFrontMatterInfo sets contentStart to the position
-		// immediately after the closing `---\n`, so text.slice(fm.end)
+		// immediately after the closing `---\n`, so text.slice(debrisEnd)
 		// begins with the blank-line `\n` (or with body text when the file
 		// has no separator). The canonical frontmatter block must therefore
 		// end with its own `\n` to preserve the blank-line separator when
 		// concatenated — omitting it drops the blank line and produces
 		// `---\nbody` on disk.
 		const canonicalFrontmatter = `---\n${yamlBody}---\n`;
-		const newText = canonicalFrontmatter + text.slice(fm.end);
+		const newText = canonicalFrontmatter + text.slice(debrisEnd);
 
 		this.applyContentToLocalDoc(newText, FRONTMATTER_MIRROR_ORIGIN);
 	}


### PR DESCRIPTION
🍋: drafted by an AI assistant working with @petergaultney

We had several documents on our ~40-user relay whose frontmatter grew without bound — the same fields repeated thousands of times in lockstep (one file reached 1MB with three fields repeated 9,840x each), regrowing within seconds of any repair. We reproduced the full mechanism with two clients on a test document and traced it to three interacting defects in the Y.Text ↔ Y.Map frontmatter mirror. This PR fixes all three.

## Mechanism (each stage reproduced on a live test document)

1. **Arm.** A user deletes a frontmatter field. `syncFrontmatterToMap`'s safety guard reads "parsed keys < ymap.size" as a corrupted parse and returns before the prune loop, so the deleted key stays in the Y.Map forever. Every client now permanently has text keys ≠ Map keys.
2. **Resurrect.** The next remote update that carries Y.Map changes (any frontmatter edit by any client) sets `_remoteFrontmatterMapUpdated`; `repairFrontmatterFromMap` sees the key-count mismatch, declares corruption, and rewrites the block with the deleted key re-appended. The user's deletion is silently undone on every client that has the file open.
3. **Duplicate.** When two clients hold *divergent* texts (one was offline while different edits happened on each side — routine on VPNs and laptops), their concurrent repair rewrites are different splices into the same region, and the CRDT merge keeps both: a key now appears twice in the YAML.
4. **Parse death.** Duplicate keys make `parseYaml` throw, so `parseFrontmatter` returns null — and both mirror directions bail on null. No code path can heal the document from here.
5. **Growth.** Each subsequent Y.Map-touching update now prepends a fresh canonical block while the corrupt one slides into the body: the file gains a whole `---` block per pass. We measured +91 bytes/pass on a 5-key fixture; our 15-key production file grew ~1,200 bytes every 11-12 seconds while two clients ping-ponged.

## Changes (all in `MergeHSM.ts`)

1. **`syncFrontmatterToMap`**: trust a clean single-block parse in full, including key deletions, so the Y.Map prunes. The corruption case the old count-guard was aimed at (double-`---` truncated parse) is detected structurally instead: if another `---` block immediately follows the parsed one, skip the prune. An ordinary deletion no longer arms the loop.
2. **`repairFrontmatterFromMap`**: recovery path for the previously-terminal states. When the frontmatter region exists but YAML fails (duplicate keys), or stray sibling blocks follow it, canonicalize the entire debris region from the Y.Map's LWW values. A trailing block is only treated as debris when it parses as a YAML mapping sharing at least one key with the Y.Map — horizontal rules and body content are never consumed.
3. **`buildDocFromYMap`**: the editor-facing document shares the same debris handling. Without this, an open editor whose buffer was built from the raw text slice re-saves the debris to disk after a repair collapses it in the Y.Text, and the doc diverges into a conflict. (The pre-existing code has the parse-null variant of this bug: `const body = fm ? text.slice(fm.end) : text` concatenates the canonical block with the *entire* unparseable text, duplicating the block.)

## Testing

All testing was on our own two-client setup (both clients mine — one on our internal build of 0.8.8 plus this change, one on stock 0.8.8, sharing one folder through our self-hosted relay server), with method-level logging in both running plugins. Stale-client edits were injected as transactions on a server-connected replica — byte-identical to a real client committing a frontmatter edit from a pre-deletion state.

Reproduction on stock 0.8.8 (before the fix):

- Deleting one key via an external disk edit left the key stuck in both clients' Y.Maps (guard observed skipping the prune at 4 parsed vs 5 map keys).
- One simulated stale-client edit resurrected the deleted key on both clients ~37s later, via concurrent repairs.
- Repeating with divergent bases (one client offline, a different key deleted on each side, reconnect) produced a duplicated key, then an unparseable block, then +1 full `---` block on the next Map touch, ending in `active.conflict`.

With the fix (mixed: one fixed client, one stock):

- The same deletion pruned the Y.Map, and the prune propagated to the *stock* client too (the Y.Map is shared state, so one fixed client heals the key set for files it has open).
- The same stale-client edit that previously resurrected the key: the repair ran, found text keys == map keys, and did nothing. 90-second soak: no resurrection, no growth, both disks byte-identical, single frontmatter block.
- A manufactured duplicate-key (unparseable) document was canonicalized to a clean single block by the repair on the next Map-touching update.

Not yet verified:

- Only single-author testing so far; no multi-user fleet exposure yet.
- The Yjs-level duplication in stage 3 can still occur while a *fixed* client is hibernating and an unfixed client rewrites concurrently — the fixed client heals it when next active, but mixed-version fleets will still see transient duplicates until fully upgraded.
