### PR TITLE
fix: don't mint a document identity from read-only observers

### DIFF
--- a/src/CanvasPlugin.ts
+++ b/src/CanvasPlugin.ts
@@ -25,7 +25,7 @@ import * as Y from "yjs";
 import { ViewHookPlugin } from "./plugins/ViewHookPlugin";
 import type { EditorViewRef } from "./merge-hsm/types";
 import { HSMEditorPlugin } from "./merge-hsm/integration/HSMEditorPlugin";
-import type { Document } from "./Document";
+import { isDocument, type Document } from "./Document";
 
 export class CanvasPlugin extends HasLogging {
 	view: CanvasView;
@@ -311,7 +311,13 @@ export class CanvasPlugin extends HasLogging {
 			(() => {
 				let document: Document;
 				try {
-					document = this.relayCanvas.sharedFolder.proxy.getDoc(embedView.file.path);
+					const candidate = this.relayCanvas.sharedFolder.proxy.findFile(
+						embedView.file,
+					);
+					if (!candidate || !isDocument(candidate)) {
+						return () => {};
+					}
+					document = candidate;
 				} catch {
 					// No shared handle (membership refused or undecided): the
 					// embed renders without live sync.

--- a/src/Document.ts
+++ b/src/Document.ts
@@ -27,7 +27,7 @@ import { trackAsyncCleanup } from "./reloadUtils";
 import { trackPromise } from "./trackPromise";
 import { DocumentDestroyedError } from "./DocumentDestroyedError";
 
-export function isDocument(file?: IFile): file is Document {
+export function isDocument(file?: IFile | null): file is Document {
 	return file instanceof Document;
 }
 

--- a/src/LiveViews.ts
+++ b/src/LiveViews.ts
@@ -13,7 +13,7 @@ import {
 } from "obsidian";
 import ViewActions from "src/components/ViewActions.svelte";
 import * as Y from "yjs";
-import { Document } from "./Document";
+import { Document, isDocument } from "./Document";
 import type { EditorViewRef } from "./merge-hsm/types";
 import type { ConnectionState } from "./HasProvider";
 import { LoginManager } from "./LoginManager";
@@ -1355,7 +1355,9 @@ export class LiveViewManager {
 
 				let embeddedDoc: Document;
 				try {
-					embeddedDoc = folder.proxy.getDoc(filePath);
+					const candidate = folder.proxy.findFile(child.file);
+					if (!candidate || !isDocument(candidate)) continue;
+					embeddedDoc = candidate;
 				} catch {
 					// No shared handle (membership refused or undecided).
 					continue;
@@ -1467,10 +1469,11 @@ export class LiveViewManager {
 	private async getViews(): Promise<S3View[]> {
 		const views: S3View[] = [];
 		iterateTextFileViews(this.workspace, this.textViewRegistry, async (textFileView) => {
-			const viewFilePath = textFileView.file?.path;
-			if (!viewFilePath) {
+			const tfile = textFileView.file;
+			if (!tfile) {
 				return;
 			}
+			const viewFilePath = tfile.path;
 			const folder = this.sharedFolders.lookup(viewFilePath);
 			if (folder) {
 				if (!this.loginManager.loggedIn) {
@@ -1480,7 +1483,13 @@ export class LiveViewManager {
 					views.push(view);
 				} else if (folder.ready) {
 					try {
-						const doc = folder.proxy.getDoc(viewFilePath);
+						const doc = folder.proxy.findFile(tfile);
+						if (!doc || !isDocument(doc)) {
+							this.log(
+								`No tracked shared document for ${viewFilePath}; skipping view.`,
+							);
+							return;
+						}
 						const view = new LiveView<typeof textFileView>(
 							this,
 							textFileView,
@@ -1514,7 +1523,7 @@ export class LiveViewManager {
 					});
 					views.push(view);
 				} else if (folder.ready) {
-					const canvas = folder.getFile(canvasView.file);
+					const canvas = folder.findFile(canvasView.file);
 					if (isCanvas(canvas)) {
 						const view = new RelayCanvasView(this, canvasView, canvas);
 						views.push(view);

--- a/src/SharedFolder.ts
+++ b/src/SharedFolder.ts
@@ -3489,6 +3489,26 @@ export class SharedFolder extends HasProvider {
 		}
 	}
 
+	/**
+	 * Look up an already-tracked file without creating one.
+	 *
+	 * `getFile` falls through to extension-based detection when a path has no
+	 * syncStore entry, minting a document for it. That is correct for callers
+	 * reacting to a genuinely new file, but wrong for observers that only want
+	 * to notify an existing document's HSM: during a remote rename the entry
+	 * has not moved to the new vpath yet, so a lookup there mints a second
+	 * identity for a document this folder already tracks under the old vpath.
+	 * The duplicate materializes a file at the vacated path and survives a
+	 * later delete of the real one.
+	 */
+	findFile(tfile: TAbstractFile): IFile | null {
+		if (!this.syncStore.get(this.getVirtualPath(tfile.path))) {
+			return null;
+		}
+
+		return this.getFile(tfile);
+	}
+
 	getFile(tfile: TAbstractFile, update = true): IFile | null {
 		const vpath = this.getVirtualPath(tfile.path);
 		const guid = this.syncStore.get(vpath);

--- a/src/TextViewPlugin.ts
+++ b/src/TextViewPlugin.ts
@@ -1,7 +1,7 @@
 import { MarkdownView, type TextFileView } from "obsidian";
 import { getPatcher } from "./Patcher";
 import { HasLogging } from "src/debug";
-import { Document } from "./Document";
+import { Document, isDocument } from "./Document";
 import { ViewHookPlugin } from "./plugins/ViewHookPlugin";
 
 import { isLive, type LiveView } from "./LiveViews";
@@ -34,7 +34,11 @@ export class TextFileViewPlugin extends HasLogging {
 			);
 			if (folder) {
 				try {
-					const newDoc = folder.proxy.getDoc(file.path);
+					const candidate = folder.proxy.findFile(file);
+					if (!candidate || !isDocument(candidate)) {
+						return;
+					}
+					const newDoc = candidate;
 					this.warn("[TextViewPlugin] getDocument() found:", {
 						newDocPath: newDoc.path,
 						newDocGuid: newDoc.guid,

--- a/src/main.ts
+++ b/src/main.ts
@@ -1041,7 +1041,7 @@ export default class Live extends Plugin {
 						}
 					} else if (file instanceof TFile) {
 						const folder = this.sharedFolders.lookup(file.path);
-						const ifile = folder?.getFile(file);
+						const ifile = folder?.findFile(file);
 						if (ifile && isSyncFile(ifile)) {
 							menu.addItem((item) => {
 								item
@@ -1419,7 +1419,7 @@ export default class Live extends Plugin {
 				const folder = this.sharedFolders.lookup(tfile.path);
 				if (folder) {
 					vaultLog("Modify", tfile.path);
-					const file = folder.proxy.getFile(tfile);
+					const file = folder.proxy.findFile(tfile);
 					if (file && isSyncFile(file)) {
 						if (!(tfile instanceof TFile)) {
 							vaultLog(
@@ -1495,7 +1495,7 @@ export default class Live extends Plugin {
 			try {
 				const folder = plugin.sharedFolders.lookup(file.path);
 				if (folder) {
-					const doc = folder.proxy.getFile(file);
+					const doc = folder.proxy.findFile(file);
 					if (doc && isDocument(doc) && doc.hsm) {
 						doc.hsm.send(event);
 					}
@@ -1509,7 +1509,7 @@ export default class Live extends Plugin {
 			try {
 				const folder = plugin.sharedFolders.lookup(file.path);
 				if (folder) {
-					const doc = folder.proxy.getFile(file);
+					const doc = folder.proxy.findFile(file);
 					if (doc && isDocument(doc) && doc.hsm) {
 						doc.hsm.captureEditorText(contents);
 					}
@@ -1563,7 +1563,7 @@ export default class Live extends Plugin {
 							if (file instanceof TFile) {
 								const folder = plugin.sharedFolders.lookup(file.path);
 								if (folder) {
-									const doc = folder.proxy.getFile(file);
+									const doc = folder.proxy.findFile(file);
 									if (doc && isDocument(doc) && doc.hsm) {
 										// Note text is LF everywhere past this
 										// boundary.
@@ -1612,7 +1612,7 @@ export default class Live extends Plugin {
 						try {
 							const folder = plugin.sharedFolders.lookup(file.path);
 							if (folder) {
-								const doc = folder.proxy.getFile(file);
+								const doc = folder.proxy.findFile(file);
 								if (doc && isDocument(doc) && doc.hsm) {
 									// Read disk content only to compute diagnostic flags.
 									// Normalize both sides so platform EOLs never
@@ -1661,7 +1661,7 @@ export default class Live extends Plugin {
 					try {
 						const folder = plugin.sharedFolders.lookup(tfile.path);
 						if (folder) {
-							const file = folder.proxy.getFile(tfile);
+							const file = folder.proxy.findFile(tfile);
 							if (tfile instanceof TFile && file && isDocument(file)) {
 								const hsm = file.hsm;
 								if (hsm) {

--- a/src/markdownView/InvalidLinkExtension.ts
+++ b/src/markdownView/InvalidLinkExtension.ts
@@ -9,7 +9,7 @@ import {
 import { WidgetType } from "@codemirror/view";
 import { curryLog } from "src/debug";
 import { setIcon, type App, type CachedMetadata, type TFile } from "obsidian";
-import type { Document } from "../Document";
+import { isDocument, type Document } from "../Document";
 import {
 	getApp,
 	getSharedFolders,
@@ -90,7 +90,8 @@ export class InvalidLinkPluginValue {
 		const folder = sharedFolders.lookup(file.path);
 		if (!folder) return undefined;
 		try {
-			return folder.proxy.getDoc(file.path);
+			const document = folder.proxy.findFile(file);
+			return document && isDocument(document) ? document : undefined;
 		} catch {
 			return undefined;
 		}

--- a/src/merge-hsm/integration/HSMEditorPlugin.ts
+++ b/src/merge-hsm/integration/HSMEditorPlugin.ts
@@ -19,7 +19,7 @@ import { Transaction } from "@codemirror/state";
 import { editorInfoField } from "obsidian";
 import type { TFile } from "obsidian";
 import { getLiveViews } from "../../editorContext";
-import type { Document } from "../../Document";
+import { isDocument, type Document } from "../../Document";
 import type { MergeHSM } from "../MergeHSM";
 import { CM6Integration } from "./CM6Integration";
 import { ySyncAnnotation } from "./annotations";
@@ -189,7 +189,8 @@ export class HSMEditorPluginValue implements PluginValue {
     if (!folder) return null;
 
     try {
-      return folder.proxy.getDoc(file.path) as Document;
+      const document = folder.proxy.findFile(file);
+      return isDocument(document) ? document : null;
     } catch (error) {
       this.debug("resolveCurrentDocument failed", {
         filePath: file.path,

--- a/src/y-codemirror.next/RemoteSelections.ts
+++ b/src/y-codemirror.next/RemoteSelections.ts
@@ -21,8 +21,9 @@ import { getLiveViews } from "../editorContext";
 import * as Y from "yjs";
 import type { Awareness } from "y-protocols/awareness.js";
 import { curryLog } from "src/debug";
-import { editorInfoField } from "obsidian";
-import type { Document } from "../Document";
+import { editorInfoField, type TFile } from "obsidian";
+import { isDocument, type Document } from "../Document";
+import type { IFile } from "../IFile";
 
 type LiveViewBridge = {
 	document: Document;
@@ -32,7 +33,7 @@ type LiveViewManagerBridge = {
 	findView(editor: EditorView): LiveViewBridge | undefined;
 	sharedFolders: {
 		lookup(path: string):
-			| { proxy: { getDoc(path: string): Document } }
+			| { proxy: { findFile(file: TFile): IFile | null } }
 			| undefined;
 	};
 };
@@ -282,8 +283,11 @@ export class YRemoteSelectionsPluginValue implements PluginValue {
 			const folder = this.connectionManager?.sharedFolders.lookup(file.path);
 			if (folder) {
 				try {
-					this.document = folder.proxy.getDoc(file.path);
-					return this.document;
+					const document = folder.proxy.findFile(file);
+					if (document && isDocument(document)) {
+						this.document = document;
+						return this.document;
+					}
 				} catch {
 					// No shared handle (membership refused or undecided):
 					// fall through to the view fallback.

--- a/src/y-codemirror.next/UserAttributionPlugin.ts
+++ b/src/y-codemirror.next/UserAttributionPlugin.ts
@@ -11,6 +11,7 @@ import * as Y from "yjs";
 
 import { getLiveViews } from "../editorContext";
 import { usercolors } from "../User";
+import { isDocument } from "../Document";
 
 /**
  * Filter state for user-attribution highlighting.
@@ -120,7 +121,8 @@ export class UserAttributionPluginValue {
 		const folder = connectionManager?.sharedFolders.lookup(file.path);
 		let doc;
 		try {
-			doc = folder?.proxy.getDoc(file.path);
+			const candidate = folder?.proxy.findFile(file);
+			doc = isDocument(candidate) ? candidate : undefined;
 		} catch {
 			// No shared handle (membership refused or undecided).
 			doc = undefined;


### PR DESCRIPTION
🍋:

Draft - opening this for visibility.

## What happens

A move made in a shared folder can leave a duplicate file at the path the move vacated, and that duplicate survives deleting the moved file.

## Why

Lookup-only call sites across `main.ts` and the editor/view integrations resolve files only to notify an existing document, connect a view, render metadata, or offer an action. These callers already guard on the result being present and do nothing without it:

```ts
const doc = folder.proxy.getFile(file);
if (doc && isDocument(doc) && doc.hsm) { ... }
```

But `getFile()` and `getDoc()` fall through to extension-based detection when a path has no SyncStore entry, minting a document for it. Lookup-only callers do not want that behavior.

It fires during a **remote** rename. On the client that performed the move, `renameFile()` moves the SyncStore entry synchronously inside the vault event handler, so disk and entry never disagree. On every other client the rename arrives as a folder-doc update via the event stream: the SyncStore entry moves to the new vpath when the update integrates, and the disk file moves afterwards, when the observer reacts. In that gap the file still sits at the **old** path with no entry pointing at it. Any plugin that writes to the file inside that gap - a frontmatter write via `processFrontMatter` reaches the patched `vault.process` - triggers a lookup by the old vpath, which finds no entry and mints a second identity at the vacated path.

## Reproduction

Create, move, then delete in a shared folder with two clients online, all through Obsidian APIs (`vault.create`, `fileManager.renameFile`, `vault.trash`).

With a peer writing frontmatter in the window, from our server's log:

```text
12:42:22  moved=.../restest-a-origin.md -> .../restest-b-moved.md   user=A
12:42:44  Doc edited  vpath=.../restest-b-moved.md                 user=A  doc=7c01cdd8
12:42:45  New doc created: first receipt of this id                user=B  doc=f919a5c5
12:42:45  added=.../restest-a-origin.md                            user=B
12:42:47  removed=.../restest-b-moved.md                           user=A
```

`user=B` created a new document at the pre-move path 0.7 seconds before the mover's delete was recorded. The file it materialized there was still present afterwards, with a different GUID from the original.

Control: the same sequence with the delete issued immediately, before any peer wrote, stayed clean - nothing tracked and nothing on disk. That isolates the concurrent write rather than the move or delete.

The peer's write came from a small in-house plugin that adds the old path as an alias on move. Any plugin with a rename hook that touches frontmatter could trigger the same lookup, which is why the fix belongs here rather than in that plugin.

## The change

Adds `SharedFolder.findFile()`, which first requires an existing SyncStore identity and returns `null` when the path is untracked. For tracked paths it delegates to `getFile()`, preserving the existing lazy loading of known files without reaching the identity-minting fallback.

Lookup-only callers in the vault observer, editor/view plugins, canvas embeds, metadata decorations, remote selections, attribution rendering, and context menu now use `findFile()`. Explicit creation and reconciliation paths continue to use `getFile()` or `getDoc()`, so genuinely new files are still placed and uploaded.

The diff is 75 additions and 28 deletions across ten files.

## Why `getFile` needs to mint, and why observers don't

`getFile` legitimately creates identities for files that exist on disk but have no SyncStore entry yet: files created while the plugin was not running, files that predate a folder being shared, or files arriving during a first sync. Without that fallback, Relay couldn't adopt files it discovers on disk.

Observers never need it. An observer reacting to an existing file (notifying its HSM, attaching a view, rendering metadata) is not discovering a new file - it's looking up one that should already be tracked. If the lookup misses, the correct response is "not my problem": either the file hasn't been discovered yet (the disk scan or create handler will get to it), or the disk file and its SyncStore entry are mid-rename and momentarily out of step. Either way, creating a second identity from an observer is always wrong.

The `create` handler in `main.ts` still calls `getFile`, so genuinely new files are placed and uploaded exactly as before. The split is between code that is *looking at* a file (use `findFile`, don't mint) vs. code that is *making* one (use `getFile`, do mint).

## Testing

- `npm run release` - clean
- `npx tsc --noEmit` - clean
- Targeted ESLint across all ten changed files
- `rg 'proxy\.getDoc\(|proxy\.getFile\('` outside `SharedFolder.ts` returns zero results

Direct observation on a patched client (via CDP): a real `TFile` at an untracked vpath (the same state a peer is in mid-rename) returns `null` from `findFile` and leaves the SyncStore unchanged. On the same client, calling `getFile` with the same input enters the mint branch and throws `"unexpectedly missing tfile or got tfolder"` from `getDoc` (no backing file on disk for the probe). The guard is deterministic - the race only determines *how* a vpath becomes untracked; once it is, `findFile`'s behavior is the same regardless of cause.

Running as a patched build on our fleet. No new duplications observed since deployment; pre-existing duplications from unpatched clients are still occurring as expected and will stop once all clients are upgraded.


