### PR TITLE
fix: gate frontmatter Y.Map value writes on provider sync

### DIFF
--- a/src/merge-hsm/MergeHSM.ts
+++ b/src/merge-hsm/MergeHSM.ts
@@ -400,6 +400,9 @@ export class MergeHSM implements MachineHSM, SyncBridgeHost {
 
 	// Whether PROVIDER_SYNCED has been received during the current lock cycle
 	private _providerSynced = false;
+	// Frontmatter value writes suppressed while unsynced; drained once the
+	// local text is reconciled merged truth (seedFrontmatterMapFromCurrentText).
+	private _frontmatterMapSyncDeferred = false;
 
 	// Async operation tracking with cancellation support
 	private _asyncOps = new Map<string, { controller: AbortController; promise: Promise<void> }>();
@@ -6571,12 +6574,32 @@ export class MergeHSM implements MachineHSM, SyncBridgeHost {
 	 */
 	private seedFrontmatterMapFromCurrentText(allowBeforeProviderSync = false): void {
 		if (!this.localDoc || !this._yaml) return;
-		if (this.localDoc.getMap("frontmatter").size > 0) return;
-		if (
-			!allowBeforeProviderSync &&
-			!this._providerSynced &&
-			!this._isProviderSynced()
-		) return;
+		const isSynced = this._providerSynced || this._isProviderSynced();
+
+		if (this.localDoc.getMap("frontmatter").size > 0) {
+			// Not a genesis seed. A deferred value write from before this sync
+			// can still be waiting on the local text - drain it now that the
+			// text is reconciled merged truth.
+			if (isSynced) this.drainDeferredFrontmatterMapSync();
+			return;
+		}
+		if (!allowBeforeProviderSync && !isSynced) return;
+
+		this.localDoc.transact(() => {
+			this.syncFrontmatterToMap(undefined, allowBeforeProviderSync);
+		}, this);
+		this._bridge.flushOutbound();
+	}
+
+	/**
+	 * Value writes suppressed while unsynced land here, from the local text
+	 * only once it is reconciled merged truth. PROVIDER_SYNCED alone is too
+	 * early for a returning client: the text merge for this reconnect may
+	 * not have applied yet, and draining against stale text would push the
+	 * exact value this fix exists to keep off the wire.
+	 */
+	private drainDeferredFrontmatterMapSync(): void {
+		if (!this._frontmatterMapSyncDeferred || !this.localDoc || !this._yaml) return;
 
 		this.localDoc.transact(() => {
 			this.syncFrontmatterToMap();
@@ -6584,7 +6607,10 @@ export class MergeHSM implements MachineHSM, SyncBridgeHost {
 		this._bridge.flushOutbound();
 	}
 
-	private syncFrontmatterToMap(previousText?: string): void {
+	private syncFrontmatterToMap(
+		previousText?: string,
+		allowUnsyncedValueWrites = false,
+	): void {
 		if (!this.localDoc || !this._yaml) return;
 
 		const text = this.localDoc.getText("contents").toString();
@@ -6625,6 +6651,24 @@ export class MergeHSM implements MachineHSM, SyncBridgeHost {
 		// Store changed values as JSON strings for faithful round-tripping.
 		// Enrollment omits previousText to seed a full baseline. Edit paths
 		// provide it so unchanged stale values never become map writes.
+		//
+		// Values follow the same discipline as key pruning below: the map is
+		// LWW, so a value written from not-yet-synced text is a fresh op
+		// that beats every peer's older-but-newer-in-truth write. Defer
+		// those until the text is reconciled merged truth (drained by
+		// seedFrontmatterMapFromCurrentText). The genesis enrollment seed
+		// bypasses the gate: its text is the causal baseline and there are
+		// no peers yet to clobber.
+		const canWriteValues =
+			allowUnsyncedValueWrites ||
+			this._providerSynced ||
+			this._isProviderSynced();
+		if (canWriteValues && this._frontmatterMapSyncDeferred) {
+			// A deferral is pending: widen this write to a full text-vs-map
+			// reconciliation so the values it suppressed land now too.
+			previousParsed = null;
+			this._frontmatterMapSyncDeferred = false;
+		}
 		for (const [key, value] of Object.entries(fm.parsed)) {
 			const serialized = JSON.stringify(value);
 			if (
@@ -6632,6 +6676,11 @@ export class MergeHSM implements MachineHSM, SyncBridgeHost {
 				!(key in previousParsed) ||
 				JSON.stringify(previousParsed[key]) !== serialized
 			) {
+				if (ymap.get(key) === serialized) continue;
+				if (!canWriteValues) {
+					this._frontmatterMapSyncDeferred = true;
+					continue;
+				}
 				ymap.set(key, serialized);
 			}
 		}


### PR DESCRIPTION
🍋:

## What happens

A returning client (offline, or otherwise behind on the server's merged state) can silently revert a frontmatter value that another client edited while it was gone - not just on itself, but on every client, including the one that made the edit. No conflict banner appears anywhere; the value just changes back.

## Why

Frontmatter values live in two places: the YAML text inside `contents` (a Y.Text, sequence-merged), and a `frontmatter` Y.Map that mirrors it, used for structured lookups and repair. The map is **last-writer-wins per key**.

`syncFrontmatterToMap` already gates the map's baseline seeding and key pruning on provider sync - there's a comment explaining why ("a delete issued from stale text would destroy them for everyone"). But the ongoing value writes in the same function had no such gate, and `ymap.set` fires even when the value hasn't changed.

A client that hasn't yet reconciled its local text with the server (typically: just reconnected after being offline) can therefore write its **stale** value into the map as a brand-new LWW op, before its own text has merged. If that op's timestamp wins the race against a live client's more recent write, `repairFrontmatterFromMap` rewrites every client's text back to the stale value - the live client that made the edit loses it with no indication anything happened.

Reproduced with two clients:
1. Client A (live, connected) edits a frontmatter alias.
2. Client B was offline; before reconnecting, it independently edits the same key locally (its own local text change, unrelated to A's edit - just enough to give it a fresh, later-looking Map op once it reconnects).
3. Client B reconnects. Its stale value lands in the map before its text has reconciled.
4. Client A's editor - and its file on disk - gets rewritten back to B's older value. No conflict, no banner, nothing in the UI to explain it.

Repeating steps 1-3 a few times produces an oscillation: the value flips between the two states as each client's write races the other's.

## The change

`syncFrontmatterToMap`:
- Skips writing a value that's already equal to what's stored (agreement should never mint a new op - this alone doesn't fix the race, but it means a converged state stays converged instead of drifting from repeated no-op writes).
- Defers value writes while the provider is unsynced, tracked with one boolean. The genesis enrollment seed keeps its existing bypass (its text is the causal baseline; there's no peer state to race against yet).

`seedFrontmatterMapFromCurrentText`:
- When called on a document whose map is already populated (i.e. not a genesis seed) and the provider is synced, drains any deferred value write. By this point in the `PROVIDER_SYNCED` transition, `mergeRemoteToLocal` has already run in the same action list, so the local text reflects the reconciled merge rather than pre-merge state. Draining any earlier than that (I first tried draining directly from `markProviderSynced`) re-introduces the exact stale value the gate is meant to suppress, because the text hasn't merged yet at that point.

The diff is scoped to `syncFrontmatterToMap` and `seedFrontmatterMapFromCurrentText` in `MergeHSM.ts` - no changes to the state chart, no new actions.

## Testing

- `npx tsc --noEmit` - clean
- `npx eslint src/merge-hsm/MergeHSM.ts` - clean
- `npm run build` - clean

Reproduced and validated with two real clients (not a unit test - I didn't see existing coverage of `syncFrontmatterToMap` to extend, happy to add something if there's a preferred harness): unpatched, a live client's edit was reverted through several oscillations as a stale client reconnected repeatedly, with no conflict UI on the client that lost the value. Patched, the returning client's stale write is suppressed until its own text has reconciled with the merge, and the map converges to the same value as the text on every client.

The design intent here is that a genuine concurrent edit should surface as a held conflict for the user to resolve, not get silently auto-resolved by an arbitrary LWW race that can revert someone else's work without telling them. This change doesn't add a conflict path - it just stops the map from being a second, less-supervised place where that silent auto-resolution can happen alongside (or after) the properly-gated text merge.
