### PR TITLE
fix: never bind subpath-scoped embed editors

### DIFF
--- a/src/merge-hsm/integration/HSMEditorPlugin.ts
+++ b/src/merge-hsm/integration/HSMEditorPlugin.ts
@@ -22,6 +22,7 @@ import { getLiveViews } from "../../editorContext";
 import { isDocument, type Document } from "../../Document";
 import type { MergeHSM } from "../MergeHSM";
 import { CM6Integration } from "./CM6Integration";
+import { subEditorKind } from "./subEditors";
 import { ySyncAnnotation } from "./annotations";
 import { curryLog } from "../../debug";
 import { formatUserFacingError } from "../../UserFacingError";
@@ -85,17 +86,16 @@ export class HSMEditorPluginValue implements PluginValue {
   private bornAttachedRenderPending = false;
   /**
    * Whether this EditorView has been identified as an embedded sub-editor:
-   * an editor another editor spawns inside itself over the same file, like
-   * the per-cell editor Obsidian's Live Preview table widget creates when a
-   * table cell is edited. A sub-editor inherits the host view's
-   * editorInfoField, so file identity, document resolution, and
-   * source-view DOM ancestry all match the host — but its buffer holds only
-   * a fragment of the note, and the spawning machinery persists whatever is
-   * dispatched into it back into the note as a user edit. Binding one to
-   * the merge machinery would render the full document into a fragment
-   * buffer (and the widget would then write that full document into one
-   * cell of the real note) and would feed fragment text back as document
-   * content. Sticky: once detected, this instance is permanently inert.
+   * an editor opened over a fragment of a file another view already owns —
+   * a Live Preview table cell, or a subpath-scoped editable embed such as
+   * the footnotes pane's per-footnote embed. A sub-editor's info field
+   * names the same file as its host, so file identity, document resolution,
+   * and source-view DOM ancestry all match — but its buffer holds only the
+   * fragment, and the spawner writes that buffer back into the fragment's
+   * span of the note. Binding one would render the full document into the
+   * fragment buffer, which the spawner then persists into that span, and
+   * would feed fragment text back as document content. Sticky: once
+   * detected, this instance is permanently inert.
    */
   private subEditor = false;
   private bindingEpoch = 0;
@@ -243,21 +243,28 @@ export class HSMEditorPluginValue implements PluginValue {
   }
 
   /**
-   * Detect an embedded sub-editor by its container: the Live Preview table
-   * widget mounts the per-cell editor it spawns inside a
-   * `.table-cell-wrapper` element. Detection is sticky and fully inerts
-   * this instance — the widget forwards every transaction it does not
-   * recognize into the host note, so nothing may ever be dispatched into
-   * such an editor. The wrapper is only observable once the editor's DOM is
-   * attached, so a negative answer means "not detected", never "proven to
-   * be a view's own editor"; the owner-identity check in probeBornAttached
-   * covers the window before the DOM is attached.
+   * A sub-editor's buffer holds a fragment of the note, so binding one
+   * would render the whole document into it, and the spawner persists that
+   * buffer back into the fragment's span of the note. Detection is sticky
+   * and fully inerts this instance — the spawner forwards or persists every
+   * transaction it does not recognize, so nothing may ever be dispatched
+   * into such an editor. A negative answer from the DOM arm is only "not
+   * detected"; the owner-identity check in probeBornAttached covers the
+   * window before the DOM is attached.
    */
   private probeSubEditor(): boolean {
     if (this.subEditor) return true;
-    if (!this.editor.dom.closest(".table-cell-wrapper")) return false;
+    // `subpath` is set on editable embeds but absent from MarkdownFileInfo's
+    // public typing.
+    const kind = subEditorKind(
+      this.editor.state.field(editorInfoField, false) as
+        | { subpath?: string }
+        | undefined,
+      this.editor.dom,
+    );
+    if (!kind) return false;
     this.subEditor = true;
-    this.log("Refusing to bind an embedded table-cell editor");
+    this.log(`Refusing to bind ${kind}`);
     if (this.cm6Integration) {
       this.cm6Integration.destroy();
       this.cm6Integration = null;

--- a/src/merge-hsm/integration/subEditors.ts
+++ b/src/merge-hsm/integration/subEditors.ts
@@ -1,0 +1,29 @@
+/**
+ * Name the kind of embedded sub-editor an editor is, or null if it is not
+ * recognizable as one. A sub-editor is an editor opened over a fragment of a
+ * file some other view already owns; binding one to the merge machinery
+ * renders the whole document into the fragment's buffer, which the spawner
+ * then persists into the fragment's span of the note.
+ *
+ * Two spawners are known:
+ *
+ * - Live Preview's table widget mounts a per-cell editor inside a
+ *   `.table-cell-wrapper` element. The wrapper is only observable once the
+ *   editor's DOM is attached, so a null answer means "not detected", never
+ *   "proven to be a view's own editor".
+ * - Editable embeds scoped by a subpath — the footnotes pane's per-footnote
+ *   embeds (`#[^1]`), heading and block embeds — put the embed itself in
+ *   editorInfoField, so its `file` matches the note and every identity check
+ *   passes. The subpath is set at embed construction, so this arm answers
+ *   even while the editor's DOM is detached. Whole-file editable embeds
+ *   (canvas file nodes) carry no subpath and are not sub-editors.
+ */
+export function subEditorKind(
+	info: { subpath?: string } | null | undefined,
+	dom: { closest(selector: string): unknown },
+): string | null {
+	if (info?.subpath) return "a subpath-scoped embed editor";
+	if (dom.closest(".table-cell-wrapper")) return "an embedded table-cell editor";
+
+	return null;
+}


### PR DESCRIPTION
🍋:

Clicking a footnote in the footnotes pane (core plugin, Obsidian 1.13) writes the entire note into
that footnote's definition, recursively, on every click.

The footnotes pane opens an **editable embed per footnote**, with subpath `#[^1]`. The embed itself
is the `editorInfoField` value, so its `file` is the host note and every identity check in
`initializeIfReady` passes. The born-attached render then replaces the fragment buffer with the
whole document, and the embed persists `before + buffer + after` on save — so the whole note lands
in the footnote's span, and the next click nests another copy. Heading and block embeds
(`#Heading`, `#^block-id`) share the shape.

This is the same failure as the table-cell sub-editor, but the existing guard cannot see it: a
subpath embed is not inside `.table-cell-wrapper`, and DOM ancestry is unavailable anyway while the
editor is still detached. The subpath is set at embed construction, so it answers during exactly
that window.

Whole-file editable embeds — canvas file nodes — carry no subpath and still bind, which is why the
check is on subpath rather than on "is an embed".

`subEditorKind()` moves the decision into its own module so it is reachable from a test without the
plugin's import graph (`Document` → `LoginManager` → `pocketbase`).

## Verification

Reproduced and fixed against a shared folder, both directions: before, one click grew a 64-byte
probe note to 141 bytes with the note nested inside its own footnote; after, the same click left
the file byte-identical and the embed buffer held only the footnote text. A non-shared note was
never affected, which is what identifies the write as the binding rather than Obsidian's own
behaviour. Normal editors still bind and sync (a typed edit reached the CRDT), and the table-cell
path is unchanged.

**No test is included.** `__tests__/**` is git-crypt encrypted and I have no key, so I could
neither read `table-cell-sub-editor.test.ts` for its conventions nor add a file there that would be
reviewable in the diff. `subEditorKind` is a pure function of `(info, dom)` and takes both as
plain structural arguments, so it should be straightforward to cover in your harness — happy to
write the test if you can share the key or point me at an unencrypted example.

Running as `0.8.9-th.6` on our internal fork.
